### PR TITLE
Fix response object in GetMarketsCandles

### DIFF
--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Candle.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Candle.java
@@ -1,0 +1,14 @@
+package io.contek.invoker.ftx.api.common;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class _Candle {
+
+  public Double close;
+  public Double high;
+  public Double low;
+  public Double open;
+  public String startTime;
+  public Double volume;
+}

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/rest/market/GetMarketsCandles.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/rest/market/GetMarketsCandles.java
@@ -3,7 +3,7 @@ package io.contek.invoker.ftx.api.rest.market;
 import io.contek.invoker.commons.actor.IActor;
 import io.contek.invoker.commons.rest.RestContext;
 import io.contek.invoker.commons.rest.RestParams;
-import io.contek.invoker.ftx.api.common._Market;
+import io.contek.invoker.ftx.api.common._Candle;
 import io.contek.invoker.ftx.api.rest.common.RestResponse;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -30,6 +30,7 @@ public final class GetMarketsCandles extends MarketRestRequest<GetMarketsCandles
     return this;
   }
 
+  /** window length in seconds. options: 15, 60, 300, 900, 3600, 14400, 86400 */
   public GetMarketsCandles setResolution(Integer resolution) {
     this.resolution = resolution;
     return this;
@@ -84,5 +85,5 @@ public final class GetMarketsCandles extends MarketRestRequest<GetMarketsCandles
   }
 
   @NotThreadSafe
-  public static final class Response extends RestResponse<List<_Market>> {}
+  public static final class Response extends RestResponse<List<_Candle>> {}
 }


### PR DESCRIPTION
The `/api/markets/{0}/candles` endpoint returns a Candle-response, not Market-response.
Ref https://docs.ftx.com/#get-historical-prices