### PR TITLE
Bybit: Add PostOrderCancelAll

### DIFF
--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_OrderCancelAll.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_OrderCancelAll.java
@@ -1,0 +1,25 @@
+package io.contek.invoker.bybit.api.common;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class _OrderCancelAll {
+
+  public String clOrdID;
+  public long user_id;
+  public String symbol;
+  public String side;
+  public String order_type;
+  public double price;
+  public int qty;
+  public String time_in_force;
+  public String create_type;
+  public String cancel_type;
+  public String order_status;
+  public int leaves_qty;
+  public double leaves_value;
+  public String created_at;
+  public String updated_at;
+  public String cross_status;
+  public long cross_seq;
+}

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/rest/user/PostOrderCancelAll.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/rest/user/PostOrderCancelAll.java
@@ -1,0 +1,66 @@
+package io.contek.invoker.bybit.api.rest.user;
+
+import com.google.common.collect.ImmutableList;
+import io.contek.invoker.bybit.api.common._OrderCancelAll;
+import io.contek.invoker.bybit.api.rest.common.RestResponse;
+import io.contek.invoker.commons.actor.IActor;
+import io.contek.invoker.commons.actor.ratelimit.RateLimitQuota;
+import io.contek.invoker.commons.rest.RestContext;
+import io.contek.invoker.commons.rest.RestMethod;
+import io.contek.invoker.commons.rest.RestParams;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.List;
+
+import static io.contek.invoker.bybit.api.ApiFactory.RateLimits.ONE_REST_PRIVATE_ORDER_WRITE_REQUEST;
+import static io.contek.invoker.bybit.api.rest.user.PostOrderCancelAll.Response;
+import static io.contek.invoker.commons.rest.RestMethod.POST;
+import static java.util.Objects.requireNonNull;
+
+@NotThreadSafe
+public final class PostOrderCancelAll extends UserRestRequest<Response> {
+
+  private String symbol;
+
+  PostOrderCancelAll(IActor actor, RestContext context) {
+    super(actor, context);
+  }
+
+  public PostOrderCancelAll setSymbol(String symbol) {
+    this.symbol = symbol;
+    return this;
+  }
+
+  @Override
+  protected RestMethod getMethod() {
+    return POST;
+  }
+
+  @Override
+  protected String getEndpointPath() {
+    return "/v2/private/order/cancelAll";
+  }
+
+  @Override
+  protected RestParams getParams() {
+    RestParams.Builder builder = RestParams.newBuilder();
+
+    requireNonNull(symbol);
+    builder.add("symbol", symbol);
+
+    return builder.build();
+  }
+
+  @Override
+  protected ImmutableList<RateLimitQuota> getRequiredQuotas() {
+    return ONE_REST_PRIVATE_ORDER_WRITE_REQUEST;
+  }
+
+  @Override
+  protected Class<Response> getResponseType() {
+    return Response.class;
+  }
+
+  @NotThreadSafe
+  public static final class Response extends RestResponse<List<_OrderCancelAll>> {}
+}

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/rest/user/UserRestApi.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/rest/user/UserRestApi.java
@@ -60,6 +60,10 @@ public final class UserRestApi {
     return new PostOrderCancel(actor, context);
   }
 
+  public PostOrderCancelAll postOrderCancelAll() {
+    return new PostOrderCancelAll(actor, context);
+  }
+
   public PostOrderCreate postOrderCreate() {
     return new PostOrderCreate(actor, context);
   }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/OrderBook200Channel.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/OrderBook200Channel.java
@@ -8,8 +8,6 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OrderBook200Channel extends OrderBookChannel<OrderBook200Channel.Id> {
 
-  public static final String TOPIC_PREFIX = "orderBook_200.100ms";
-
   public OrderBook200Channel(OrderBook200Channel.Id id) {
     super(id);
   }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/OrderBook25Channel.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/OrderBook25Channel.java
@@ -20,7 +20,7 @@ public final class OrderBook25Channel extends OrderBookChannel<OrderBook25Channe
     }
 
     public static Id of(String symbol) {
-      return new Id(String.format("orderBook_25.%s", symbol));
+      return new Id(String.format("orderBookL2_25.%s", symbol));
     }
   }
 }


### PR DESCRIPTION
Added endpoint to Bybit API to cancel all orders.

Additionally fixed Bybit Websocket OrderBook topics. The topic for the OrderBook25 was wrong, "L2" was missing.

Interestingly for the OrderBook200 the "L2" is not required. Even thought the API documentation says that the topic is "orderBookL2_200", the example code shows "orderBook_200", which is correct, I tested it.