### PR TITLE
Accept null value in RestParams

### DIFF
--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_Account.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_Account.java
@@ -13,4 +13,17 @@ public class _Account {
   public Long updateTime;
   public List<_AccountAsset> assets;
   public List<_AccountPosition> positions;
+
+  @Override
+  public String toString() {
+    return "_Account{" +
+            "canDeposit=" + canDeposit +
+            ", canTrade=" + canTrade +
+            ", canWithdraw=" + canWithdraw +
+            ", feeTier=" + feeTier +
+            ", updateTime=" + updateTime +
+            ", assets=" + assets +
+            ", positions=" + positions +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_AccountAsset.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_AccountAsset.java
@@ -17,4 +17,22 @@ public class _AccountAsset {
   public Double crossWalletBalance;
   public Double crossUnPnl;
   public Double availableBalance;
+
+  @Override
+  public String toString() {
+    return "_AccountAsset{" +
+            "asset='" + asset + '\'' +
+            ", walletBalance=" + walletBalance +
+            ", unrealizedProfit=" + unrealizedProfit +
+            ", marginBalance=" + marginBalance +
+            ", maintMargin=" + maintMargin +
+            ", initialMargin=" + initialMargin +
+            ", positionInitialMargin=" + positionInitialMargin +
+            ", openOrderInitialMargin=" + openOrderInitialMargin +
+            ", maxWithdrawAmount=" + maxWithdrawAmount +
+            ", crossWalletBalance=" + crossWalletBalance +
+            ", crossUnPnl=" + crossUnPnl +
+            ", availableBalance=" + availableBalance +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_AccountPosition.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_AccountPosition.java
@@ -16,4 +16,21 @@ public class _AccountPosition {
   public String positionSide;
   public Double entryPrice;
   public Double maxQty;
+
+  @Override
+  public String toString() {
+    return "_AccountPosition{" +
+            "symbol='" + symbol + '\'' +
+            ", initialMargin=" + initialMargin +
+            ", maintMargin=" + maintMargin +
+            ", unrealizedProfit=" + unrealizedProfit +
+            ", positionInitialMargin=" + positionInitialMargin +
+            ", openOrderInitialMargin=" + openOrderInitialMargin +
+            ", leverage=" + leverage +
+            ", isolated=" + isolated +
+            ", positionSide='" + positionSide + '\'' +
+            ", entryPrice=" + entryPrice +
+            ", maxQty=" + maxQty +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_BookTicker.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_BookTicker.java
@@ -12,4 +12,17 @@ public class _BookTicker {
   public Double askPrice;
   public Double askQty;
   public Long time;
+
+  @Override
+  public String toString() {
+    return "_BookTicker{" +
+            "symbol='" + symbol + '\'' +
+            ", pair='" + pair + '\'' +
+            ", bidPrice=" + bidPrice +
+            ", bidQty=" + bidQty +
+            ", askPrice=" + askPrice +
+            ", askQty=" + askQty +
+            ", time=" + time +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_InitialLeverageInfo.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_InitialLeverageInfo.java
@@ -8,4 +8,13 @@ public class _InitialLeverageInfo {
   public int leverage;
   public String maxNotionalValue;
   public String symbol;
+
+  @Override
+  public String toString() {
+    return "_InitialLeverageInfo{" +
+            "leverage=" + leverage +
+            ", maxNotionalValue='" + maxNotionalValue + '\'' +
+            ", symbol='" + symbol + '\'' +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_LongShortRatio.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_LongShortRatio.java
@@ -10,4 +10,15 @@ public final class _LongShortRatio {
   public double longAccount;
   public double shortAccount;
   public long timestamp;
+
+  @Override
+  public String toString() {
+    return "_LongShortRatio{" +
+            "pair='" + pair + '\'' +
+            ", longShortRatio=" + longShortRatio +
+            ", longAccount=" + longAccount +
+            ", shortAccount=" + shortAccount +
+            ", timestamp=" + timestamp +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_OpenInterest.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_OpenInterest.java
@@ -10,4 +10,15 @@ public class _OpenInterest {
   public Double openInterest;
   public String contractType;
   public Long time;
+
+  @Override
+  public String toString() {
+    return "_OpenInterest{" +
+            "symbol='" + symbol + '\'' +
+            ", pair='" + pair + '\'' +
+            ", openInterest=" + openInterest +
+            ", contractType='" + contractType + '\'' +
+            ", time=" + time +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_OpenInterestStatistics.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_OpenInterestStatistics.java
@@ -10,4 +10,15 @@ public final class _OpenInterestStatistics {
   public Double sumOpenInterest;
   public Double sumOpenInterestValue;
   public Long timestamp;
+
+  @Override
+  public String toString() {
+    return "_OpenInterestStatistics{" +
+            "pair='" + pair + '\'' +
+            ", contractType='" + contractType + '\'' +
+            ", sumOpenInterest=" + sumOpenInterest +
+            ", sumOpenInterestValue=" + sumOpenInterestValue +
+            ", timestamp=" + timestamp +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_Order.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_Order.java
@@ -30,4 +30,35 @@ public class _Order {
   public Long updateTime;
   public String workingType;
   public Boolean priceProtect;
+
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "avgPrice=" + avgPrice +
+            ", clientOrderId='" + clientOrderId + '\'' +
+            ", cumQty=" + cumQty +
+            ", cumBase=" + cumBase +
+            ", executedQty=" + executedQty +
+            ", orderId=" + orderId +
+            ", origQty=" + origQty +
+            ", origType='" + origType + '\'' +
+            ", price=" + price +
+            ", reduceOnly=" + reduceOnly +
+            ", side='" + side + '\'' +
+            ", positionSide='" + positionSide + '\'' +
+            ", status='" + status + '\'' +
+            ", stopPrice=" + stopPrice +
+            ", closePosition=" + closePosition +
+            ", symbol='" + symbol + '\'' +
+            ", pair='" + pair + '\'' +
+            ", time=" + time +
+            ", timeInForce='" + timeInForce + '\'' +
+            ", type='" + type + '\'' +
+            ", activatePrice=" + activatePrice +
+            ", priceRate=" + priceRate +
+            ", updateTime=" + updateTime +
+            ", workingType='" + workingType + '\'' +
+            ", priceProtect=" + priceProtect +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_PositionMode.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_PositionMode.java
@@ -6,4 +6,11 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class _PositionMode {
 
   public boolean dualSidePosition;
+
+  @Override
+  public String toString() {
+    return "_PositionMode{" +
+            "dualSidePosition=" + dualSidePosition +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_PositionRisk.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_PositionRisk.java
@@ -17,4 +17,22 @@ public class _PositionRisk {
   public Double isolatedMargin;
   public Boolean isAutoAddMargin;
   public String positionSide;
+
+  @Override
+  public String toString() {
+    return "_PositionRisk{" +
+            "symbol='" + symbol + '\'' +
+            ", positionAmt=" + positionAmt +
+            ", entryPrice=" + entryPrice +
+            ", markPrice=" + markPrice +
+            ", unRealizedProfit=" + unRealizedProfit +
+            ", liquidationPrice=" + liquidationPrice +
+            ", leverage=" + leverage +
+            ", maxQty=" + maxQty +
+            ", marginType='" + marginType + '\'' +
+            ", isolatedMargin=" + isolatedMargin +
+            ", isAutoAddMargin=" + isAutoAddMargin +
+            ", positionSide='" + positionSide + '\'' +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_Trade.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/common/_Trade.java
@@ -11,4 +11,16 @@ public class _Trade {
   public Double baseQty;
   public Long time;
   public Boolean isBuyerMaker;
+
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "id=" + id +
+            ", price=" + price +
+            ", qty=" + qty +
+            ", baseQty=" + baseQty +
+            ", time=" + time +
+            ", isBuyerMaker=" + isBuyerMaker +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/rest/market/GetDepth.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/rest/market/GetDepth.java
@@ -99,5 +99,16 @@ public final class GetDepth extends MarketRestRequest<Response> {
 
     public List<_OrderBookLevel> bids;
     public List<_OrderBookLevel> asks;
+
+    @Override
+    public String toString() {
+      return "Response{" +
+              "lastUpdateId=" + lastUpdateId +
+              ", E=" + E +
+              ", T=" + T +
+              ", bids=" + bids +
+              ", asks=" + asks +
+              '}';
+    }
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/rest/market/GetExchangeInfo.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/rest/market/GetExchangeInfo.java
@@ -65,5 +65,27 @@ public final class GetExchangeInfo extends MarketRestRequest<Response> {
     public Integer quotePrecision;
     public String underlyingType;
     public List<Map<String, Object>> filters;
+
+    @Override
+    public String toString() {
+      return "MarketDetails{" +
+              "symbol='" + symbol + '\'' +
+              ", pair='" + pair + '\'' +
+              ", contractType='" + contractType + '\'' +
+              ", deliveryDate=" + deliveryDate +
+              ", onboardDate=" + onboardDate +
+              ", contractStatus='" + contractStatus + '\'' +
+              ", contractSize=" + contractSize +
+              ", quoteAsset='" + quoteAsset + '\'' +
+              ", baseAsset='" + baseAsset + '\'' +
+              ", marginAsset='" + marginAsset + '\'' +
+              ", pricePrecision=" + pricePrecision +
+              ", quantityPrecision=" + quantityPrecision +
+              ", baseAssetPrecision=" + baseAssetPrecision +
+              ", quotePrecision=" + quotePrecision +
+              ", underlyingType='" + underlyingType + '\'' +
+              ", filters=" + filters +
+              '}';
+    }
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/rest/user/PostListenKey.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/rest/user/PostListenKey.java
@@ -49,5 +49,12 @@ public final class PostListenKey extends UserRestRequest<PostListenKey.Response>
   public static final class Response {
 
     public String listenKey;
+
+    @Override
+    public String toString() {
+      return "Response{" +
+              "listenKey='" + listenKey + '\'' +
+              '}';
+    }
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/AggTradeEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/AggTradeEvent.java
@@ -15,4 +15,18 @@ public class AggTradeEvent extends WebSocketEventMessage {
   public Long l; // Last trade ID
   public Long T; // Trade time
   public Boolean m; // Is the buyer the market maker?
+
+  @Override
+  public String toString() {
+    return "AggTradeEvent{" +
+            "s='" + s + '\'' +
+            ", a=" + a +
+            ", p=" + p +
+            ", q=" + q +
+            ", f=" + f +
+            ", l=" + l +
+            ", T=" + T +
+            ", m=" + m +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/BookTickerEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/BookTickerEvent.java
@@ -15,4 +15,18 @@ public class BookTickerEvent extends WebSocketEventMessage {
   public Double B; // best bid qty
   public Double a; // best ask price
   public Double A; // best ask qty
+
+  @Override
+  public String toString() {
+    return "BookTickerEvent{" +
+            "u=" + u +
+            ", T=" + T +
+            ", s='" + s + '\'' +
+            ", ps='" + ps + '\'' +
+            ", b=" + b +
+            ", B=" + B +
+            ", a=" + a +
+            ", A=" + A +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/DepthUpdateEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/DepthUpdateEvent.java
@@ -17,4 +17,18 @@ public class DepthUpdateEvent extends WebSocketEventMessage {
   public long pu; // last update Id in last stream (ie ‘u’ in last stream)
   public List<_OrderBookLevel> b; // Bids to be updated [Price level to be updated, Quantity]
   public List<_OrderBookLevel> a; // Asks to be updated [Price level to be updated, Quantity]
+
+  @Override
+  public String toString() {
+    return "DepthUpdateEvent{" +
+            "T=" + T +
+            ", s='" + s + '\'' +
+            ", ps='" + ps + '\'' +
+            ", U=" + U +
+            ", u=" + u +
+            ", pu=" + pu +
+            ", b=" + b +
+            ", a=" + a +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/ForceOrderEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/ForceOrderEvent.java
@@ -24,5 +24,30 @@ public class ForceOrderEvent extends WebSocketEventMessage {
     public Double l; // Order Last Filled Quantity
     public Double z; // Order Filled Accumulated Quantity
     public Long T; // Order Trade Time
+
+    @Override
+    public String toString() {
+      return "Order{" +
+              "s='" + s + '\'' +
+              ", ps='" + ps + '\'' +
+              ", S='" + S + '\'' +
+              ", o='" + o + '\'' +
+              ", f='" + f + '\'' +
+              ", q=" + q +
+              ", p=" + p +
+              ", a=" + a +
+              ", X='" + X + '\'' +
+              ", l=" + l +
+              ", z=" + z +
+              ", T=" + T +
+              '}';
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "ForceOrderEvent{" +
+            "o=" + o +
+            '}';
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/KlineEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/KlineEvent.java
@@ -11,6 +11,15 @@ public class KlineEvent extends WebSocketEventMessage {
   public String ps; // Pair
   public Candle k;
 
+  @Override
+  public String toString() {
+    return "KlineEvent{" +
+            "s='" + s + '\'' +
+            ", ps='" + ps + '\'' +
+            ", k=" + k +
+            '}';
+  }
+
   @NotThreadSafe
   public static class Candle {
 
@@ -30,5 +39,27 @@ public class KlineEvent extends WebSocketEventMessage {
     public Double q; // Quote asset volume
     public Double V; // Taker buy base asset volume
     public Double Q; // Taker buy quote asset volume
+
+    @Override
+    public String toString() {
+      return "Candle{" +
+              "t=" + t +
+              ", T=" + T +
+              ", s='" + s + '\'' +
+              ", i='" + i + '\'' +
+              ", f=" + f +
+              ", L=" + L +
+              ", o=" + o +
+              ", c=" + c +
+              ", h=" + h +
+              ", l=" + l +
+              ", v=" + v +
+              ", n=" + n +
+              ", x=" + x +
+              ", q=" + q +
+              ", V=" + V +
+              ", Q=" + Q +
+              '}';
+    }
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/MarkPriceUpdateEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/MarkPriceUpdateEvent.java
@@ -11,4 +11,14 @@ public class MarkPriceUpdateEvent extends WebSocketEventMessage {
   public Double p; // Mark price
   public Double r; // Funding rate
   public Long T; // Next funding time
+
+  @Override
+  public String toString() {
+    return "MarkPriceUpdateEvent{" +
+            "s='" + s + '\'' +
+            ", p=" + p +
+            ", r=" + r +
+            ", T=" + T +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/MiniTickerEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/MiniTickerEvent.java
@@ -15,4 +15,18 @@ public class MiniTickerEvent extends WebSocketEventMessage {
   public Double l; // Low price
   public Double v; // Total traded base asset volume
   public Double q; // Total traded quote asset volume
+
+  @Override
+  public String toString() {
+    return "MiniTickerEvent{" +
+            "s='" + s + '\'' +
+            ", ps='" + ps + '\'' +
+            ", c=" + c +
+            ", o=" + o +
+            ", h=" + h +
+            ", l=" + l +
+            ", v=" + v +
+            ", q=" + q +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/TickerEvent.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/TickerEvent.java
@@ -23,4 +23,26 @@ public class TickerEvent extends WebSocketEventMessage {
   public Long F; // First trade ID
   public Long L; // Last trade Id
   public Integer n; // Total number of trades
+
+  @Override
+  public String toString() {
+    return "TickerEvent{" +
+            "s='" + s + '\'' +
+            ", p=" + p +
+            ", P=" + P +
+            ", w=" + w +
+            ", c=" + c +
+            ", Q=" + Q +
+            ", o=" + o +
+            ", h=" + h +
+            ", l=" + l +
+            ", v=" + v +
+            ", q=" + q +
+            ", O=" + O +
+            ", C=" + C +
+            ", F=" + F +
+            ", L=" + L +
+            ", n=" + n +
+            '}';
+  }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/AccountConfigUpdateChannel.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/AccountConfigUpdateChannel.java
@@ -43,6 +43,22 @@ public final class AccountConfigUpdateChannel
 
       public String s; // symbol
       public Integer l; // leverage
+
+      @Override
+      public String toString() {
+        return "AccountConfig{" +
+                "s='" + s + '\'' +
+                ", l=" + l +
+                '}';
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "Message{" +
+              "T=" + T +
+              ", ac=" + ac +
+              '}';
     }
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/AccountUpdateChannel.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/AccountUpdateChannel.java
@@ -39,12 +39,29 @@ public final class AccountUpdateChannel
     public Long T; // transaction
     public UpdateData a; // account update
 
+    @Override
+    public String toString() {
+      return "Message{" +
+              "T=" + T +
+              ", a=" + a +
+              '}';
+    }
+
     @NotThreadSafe
     public static final class UpdateData {
 
       public String m; // event reason type
       public List<BalanceUpdate> B; // balance updates
       public List<PositionUpdate> P; // position updates
+
+      @Override
+      public String toString() {
+        return "UpdateData{" +
+                "m='" + m + '\'' +
+                ", B=" + B +
+                ", P=" + P +
+                '}';
+      }
     }
   }
 
@@ -54,6 +71,15 @@ public final class AccountUpdateChannel
     public String a; // asset
     public BigDecimal wb; // wallet balance
     public BigDecimal cw; // cross wallet balance
+
+    @Override
+    public String toString() {
+      return "BalanceUpdate{" +
+              "a='" + a + '\'' +
+              ", wb=" + wb +
+              ", cw=" + cw +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -67,5 +93,19 @@ public final class AccountUpdateChannel
     public String mt; // margin type
     public BigDecimal iw; // isolated wallet
     public String ps; // position side
+
+    @Override
+    public String toString() {
+      return "PositionUpdate{" +
+              "s='" + s + '\'' +
+              ", pa=" + pa +
+              ", ep=" + ep +
+              ", cr=" + cr +
+              ", up=" + up +
+              ", mt='" + mt + '\'' +
+              ", iw=" + iw +
+              ", ps='" + ps + '\'' +
+              '}';
+    }
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/MarginCallChannel.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/MarginCallChannel.java
@@ -38,6 +38,14 @@ public final class MarginCallChannel
     public Double cw; // transaction time
     public List<PositionForMarginCall> p;
 
+    @Override
+    public String toString() {
+      return "Message{" +
+              "cw=" + cw +
+              ", p=" + p +
+              '}';
+    }
+
     @NotThreadSafe
     public static class PositionForMarginCall {
 
@@ -48,6 +56,19 @@ public final class MarginCallChannel
       public Double mp; // mark price
       public Double up; // unrealized PnL
       public Double mm; // maintenance margin required
+
+      @Override
+      public String toString() {
+        return "PositionForMarginCall{" +
+                "s='" + s + '\'' +
+                ", ps='" + ps + '\'' +
+                ", mt='" + mt + '\'' +
+                ", iw=" + iw +
+                ", mp=" + mp +
+                ", up=" + up +
+                ", mm=" + mm +
+                '}';
+      }
     }
   }
 }

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/OrderUpdateChannel.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/OrderUpdateChannel.java
@@ -37,6 +37,14 @@ public final class OrderUpdateChannel
     public long T; // trasnaction time
     public Order o;
 
+    @Override
+    public String toString() {
+      return "Message{" +
+              "T=" + T +
+              ", o=" + o +
+              '}';
+    }
+
     @NotThreadSafe
     public static class Order {
 
@@ -70,6 +78,42 @@ public final class OrderUpdateChannel
       public Double AP; // activatin price
       public Double cr; // callback rate
       public Double rp; // realized profit
+
+      @Override
+      public String toString() {
+        return "Order{" +
+                "s='" + s + '\'' +
+                ", c='" + c + '\'' +
+                ", S='" + S + '\'' +
+                ", o='" + o + '\'' +
+                ", f='" + f + '\'' +
+                ", q=" + q +
+                ", p=" + p +
+                ", ap=" + ap +
+                ", sp=" + sp +
+                ", x='" + x + '\'' +
+                ", X='" + X + '\'' +
+                ", i=" + i +
+                ", l=" + l +
+                ", z=" + z +
+                ", L=" + L +
+                ", N='" + N + '\'' +
+                ", n='" + n + '\'' +
+                ", T=" + T +
+                ", t=" + t +
+                ", b=" + b +
+                ", a=" + a +
+                ", m=" + m +
+                ", R=" + R +
+                ", wt='" + wt + '\'' +
+                ", ot='" + ot + '\'' +
+                ", ps='" + ps + '\'' +
+                ", cp=" + cp +
+                ", AP=" + AP +
+                ", cr=" + cr +
+                ", rp=" + rp +
+                '}';
+      }
     }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_Account.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_Account.java
@@ -24,4 +24,28 @@ public class _Account {
   public Double maxWithdrawAmount;
   public List<_AccountAsset> assets;
   public List<_AccountPosition> positions;
+
+  @Override
+  public String toString() {
+    return "_Account{" +
+            "feeTier=" + feeTier +
+            ", canDeposit=" + canDeposit +
+            ", canTrade=" + canTrade +
+            ", canWithdraw=" + canWithdraw +
+            ", updateTime=" + updateTime +
+            ", totalInitialMargin=" + totalInitialMargin +
+            ", totalMaintMargin=" + totalMaintMargin +
+            ", totalWalletBalance=" + totalWalletBalance +
+            ", totalUnrealizedProfit=" + totalUnrealizedProfit +
+            ", totalMarginBalance=" + totalMarginBalance +
+            ", totalPositionInitialMargin=" + totalPositionInitialMargin +
+            ", totalOpenOrderInitialMargin=" + totalOpenOrderInitialMargin +
+            ", totalCrossWalletBalance=" + totalCrossWalletBalance +
+            ", totalCrossUnPnl=" + totalCrossUnPnl +
+            ", availableBalance=" + availableBalance +
+            ", maxWithdrawAmount=" + maxWithdrawAmount +
+            ", assets=" + assets +
+            ", positions=" + positions +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_AccountAsset.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_AccountAsset.java
@@ -17,4 +17,22 @@ public class _AccountAsset {
   public Double crossUnPnl;
   public Double availableBalance;
   public Double maxWithdrawAmount;
+
+  @Override
+  public String toString() {
+    return "_AccountAsset{" +
+            "asset='" + asset + '\'' +
+            ", walletBalance=" + walletBalance +
+            ", unrealizedProfit=" + unrealizedProfit +
+            ", marginBalance=" + marginBalance +
+            ", maintMargin=" + maintMargin +
+            ", initialMargin=" + initialMargin +
+            ", positionInitialMargin=" + positionInitialMargin +
+            ", openOrderInitialMargin=" + openOrderInitialMargin +
+            ", crossWalletBalance=" + crossWalletBalance +
+            ", crossUnPnl=" + crossUnPnl +
+            ", availableBalance=" + availableBalance +
+            ", maxWithdrawAmount=" + maxWithdrawAmount +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_AccountPosition.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_AccountPosition.java
@@ -16,4 +16,21 @@ public class _AccountPosition {
   public Double entryPrice;
   public Double maxNotional;
   public String positionSide;
+
+  @Override
+  public String toString() {
+    return "_AccountPosition{" +
+            "symbol='" + symbol + '\'' +
+            ", initialMargin=" + initialMargin +
+            ", maintMargin=" + maintMargin +
+            ", unrealizedProfit=" + unrealizedProfit +
+            ", positionInitialMargin=" + positionInitialMargin +
+            ", leverage=" + leverage +
+            ", isolated=" + isolated +
+            ", openOrderInitialMargin=" + openOrderInitialMargin +
+            ", entryPrice=" + entryPrice +
+            ", maxNotional=" + maxNotional +
+            ", positionSide='" + positionSide + '\'' +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_BookTicker.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_BookTicker.java
@@ -11,4 +11,16 @@ public class _BookTicker {
   public Double askPrice;
   public Double askQty;
   public Long time;
+
+  @Override
+  public String toString() {
+    return "_BookTicker{" +
+            "symbol='" + symbol + '\'' +
+            ", bidPrice=" + bidPrice +
+            ", bidQty=" + bidQty +
+            ", askPrice=" + askPrice +
+            ", askQty=" + askQty +
+            ", time=" + time +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_InitialLeverageInfo.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_InitialLeverageInfo.java
@@ -8,4 +8,13 @@ public class _InitialLeverageInfo {
   public int leverage;
   public String maxNotionalValue;
   public String symbol;
+
+  @Override
+  public String toString() {
+    return "_InitialLeverageInfo{" +
+            "leverage=" + leverage +
+            ", maxNotionalValue='" + maxNotionalValue + '\'' +
+            ", symbol='" + symbol + '\'' +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_LongShortRatio.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_LongShortRatio.java
@@ -10,4 +10,15 @@ public final class _LongShortRatio {
   public double longAccount;
   public double shortAccount;
   public long timestamp;
+
+  @Override
+  public String toString() {
+    return "_LongShortRatio{" +
+            "symbol='" + symbol + '\'' +
+            ", longShortRatio=" + longShortRatio +
+            ", longAccount=" + longAccount +
+            ", shortAccount=" + shortAccount +
+            ", timestamp=" + timestamp +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_OpenInterest.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_OpenInterest.java
@@ -8,4 +8,13 @@ public class _OpenInterest {
   public String symbol;
   public Double openInterest;
   public Long time;
+
+  @Override
+  public String toString() {
+    return "_OpenInterest{" +
+            "symbol='" + symbol + '\'' +
+            ", openInterest=" + openInterest +
+            ", time=" + time +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_OpenInterestStatistics.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_OpenInterestStatistics.java
@@ -9,4 +9,14 @@ public final class _OpenInterestStatistics {
   public Double sumOpenInterest;
   public Double sumOpenInterestValue;
   public Long timestamp;
+
+  @Override
+  public String toString() {
+    return "_OpenInterestStatistics{" +
+            "symbol='" + symbol + '\'' +
+            ", sumOpenInterest=" + sumOpenInterest +
+            ", sumOpenInterestValue=" + sumOpenInterestValue +
+            ", timestamp=" + timestamp +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_Order.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_Order.java
@@ -21,4 +21,26 @@ public class _Order {
   public Double stopPrice;
   public Long updateTime;
   public String workingType;
+
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "symbol='" + symbol + '\'' +
+            ", orderId=" + orderId +
+            ", clientOrderId='" + clientOrderId + '\'' +
+            ", price=" + price +
+            ", avgPrice=" + avgPrice +
+            ", origQty=" + origQty +
+            ", executedQty=" + executedQty +
+            ", status='" + status + '\'' +
+            ", timeInForce='" + timeInForce + '\'' +
+            ", type='" + type + '\'' +
+            ", reduceOnly=" + reduceOnly +
+            ", side='" + side + '\'' +
+            ", positionSide='" + positionSide + '\'' +
+            ", stopPrice=" + stopPrice +
+            ", updateTime=" + updateTime +
+            ", workingType='" + workingType + '\'' +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_PositionMode.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_PositionMode.java
@@ -6,4 +6,11 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class _PositionMode {
 
   public boolean dualSidePosition;
+
+  @Override
+  public String toString() {
+    return "_PositionMode{" +
+            "dualSidePosition=" + dualSidePosition +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_PositionRisk.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_PositionRisk.java
@@ -17,4 +17,22 @@ public class _PositionRisk {
   public Double unRealizedProfit;
   public String positionSide;
   public long updateTime;
+
+  @Override
+  public String toString() {
+    return "_PositionRisk{" +
+            "entryPrice=" + entryPrice +
+            ", marginType='" + marginType + '\'' +
+            ", isAutoAddMargin=" + isAutoAddMargin +
+            ", isolatedMargin=" + isolatedMargin +
+            ", leverage=" + leverage +
+            ", liquidationPrice=" + liquidationPrice +
+            ", markPrice=" + markPrice +
+            ", positionAmt=" + positionAmt +
+            ", symbol='" + symbol + '\'' +
+            ", unRealizedProfit=" + unRealizedProfit +
+            ", positionSide='" + positionSide + '\'' +
+            ", updateTime=" + updateTime +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_Trade.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/common/_Trade.java
@@ -11,4 +11,16 @@ public class _Trade {
   public Long time;
   public Boolean isBuyerMaker;
   public Boolean isBestMatch;
+
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "id=" + id +
+            ", price=" + price +
+            ", qty=" + qty +
+            ", time=" + time +
+            ", isBuyerMaker=" + isBuyerMaker +
+            ", isBestMatch=" + isBestMatch +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/rest/market/GetDepth.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/rest/market/GetDepth.java
@@ -100,5 +100,16 @@ public final class GetDepth extends MarketRestRequest<Response> {
 
     public List<_OrderBookLevel> bids;
     public List<_OrderBookLevel> asks;
+
+    @Override
+    public String toString() {
+      return "Response{" +
+              "lastUpdateId=" + lastUpdateId +
+              ", E=" + E +
+              ", T=" + T +
+              ", bids=" + bids +
+              ", asks=" + asks +
+              '}';
+    }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/rest/market/GetExchangeInfo.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/rest/market/GetExchangeInfo.java
@@ -61,5 +61,22 @@ public final class GetExchangeInfo extends MarketRestRequest<Response> {
     public Integer quantityPrecision;
     
     public List<Map<String, Object>> filters;
+
+    @Override
+    public String toString() {
+      return "MarketDetails{" +
+              "symbol='" + symbol + '\'' +
+              ", status='" + status + '\'' +
+              ", maintMarginPercent=" + maintMarginPercent +
+              ", requiredMarginPercent=" + requiredMarginPercent +
+              ", baseAsset='" + baseAsset + '\'' +
+              ", quoteAsset='" + quoteAsset + '\'' +
+              ", pricePrecision=" + pricePrecision +
+              ", baseAssetPrecision=" + baseAssetPrecision +
+              ", quotePrecision=" + quotePrecision +
+              ", quantityPrecision=" + quantityPrecision +
+              ", filters=" + filters +
+              '}';
+    }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/rest/user/PostListenKey.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/rest/user/PostListenKey.java
@@ -50,5 +50,12 @@ public final class PostListenKey extends UserRestRequest<Response> {
   public static final class Response {
 
     public String listenKey;
+
+    @Override
+    public String toString() {
+      return "Response{" +
+              "listenKey='" + listenKey + '\'' +
+              '}';
+    }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/AggTradeEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/AggTradeEvent.java
@@ -15,4 +15,18 @@ public class AggTradeEvent extends WebSocketEventMessage {
   public Long l; // Last trade ID
   public Long T; // Trade time
   public Boolean m; // Is the buyer the market maker?
+
+  @Override
+  public String toString() {
+    return "AggTradeEvent{" +
+            "s='" + s + '\'' +
+            ", a=" + a +
+            ", p=" + p +
+            ", q=" + q +
+            ", f=" + f +
+            ", l=" + l +
+            ", T=" + T +
+            ", m=" + m +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/BookTickerEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/BookTickerEvent.java
@@ -14,4 +14,17 @@ public class BookTickerEvent extends WebSocketEventMessage {
   public Double B; // best bid qty
   public Double a; // best ask price
   public Double A; // best ask qty
+
+  @Override
+  public String toString() {
+    return "BookTickerEvent{" +
+            "u=" + u +
+            ", T=" + T +
+            ", s='" + s + '\'' +
+            ", b=" + b +
+            ", B=" + B +
+            ", a=" + a +
+            ", A=" + A +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/DepthUpdateEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/DepthUpdateEvent.java
@@ -16,4 +16,17 @@ public class DepthUpdateEvent extends WebSocketEventMessage {
   public long pu; // last update Id in last stream (ie ‘u’ in last stream)
   public List<_OrderBookLevel> b; // Bids to be updated [Price level to be updated, Quantity]
   public List<_OrderBookLevel> a; // Asks to be updated [Price level to be updated, Quantity]
+
+  @Override
+  public String toString() {
+    return "DepthUpdateEvent{" +
+            "T=" + T +
+            ", s='" + s + '\'' +
+            ", U=" + U +
+            ", u=" + u +
+            ", pu=" + pu +
+            ", b=" + b +
+            ", a=" + a +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/ForceOrderEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/ForceOrderEvent.java
@@ -9,6 +9,13 @@ public class ForceOrderEvent extends WebSocketEventMessage {
 
   public Order o;
 
+  @Override
+  public String toString() {
+    return "ForceOrderEvent{" +
+            "o=" + o +
+            '}';
+  }
+
   @NotThreadSafe
   public static class Order {
 
@@ -23,5 +30,22 @@ public class ForceOrderEvent extends WebSocketEventMessage {
     public Double l; // Order Last Filled Quantity
     public Double z; // Order Filled Accumulated Quantity
     public Long T; // Order Trade Time
+
+    @Override
+    public String toString() {
+      return "Order{" +
+              "s='" + s + '\'' +
+              ", S='" + S + '\'' +
+              ", o='" + o + '\'' +
+              ", f='" + f + '\'' +
+              ", q=" + q +
+              ", p=" + p +
+              ", a=" + a +
+              ", X='" + X + '\'' +
+              ", l=" + l +
+              ", z=" + z +
+              ", T=" + T +
+              '}';
+    }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/KlineEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/KlineEvent.java
@@ -10,6 +10,14 @@ public class KlineEvent extends WebSocketEventMessage {
   public String s; // Symbol
   public Candle k;
 
+  @Override
+  public String toString() {
+    return "KlineEvent{" +
+            "s='" + s + '\'' +
+            ", k=" + k +
+            '}';
+  }
+
   @NotThreadSafe
   public static class Candle {
 
@@ -29,5 +37,27 @@ public class KlineEvent extends WebSocketEventMessage {
     public Double q; // Quote asset volume
     public Double V; // Taker buy base asset volume
     public Double Q; // Taker buy quote asset volume
+
+    @Override
+    public String toString() {
+      return "Candle{" +
+              "t=" + t +
+              ", T=" + T +
+              ", s='" + s + '\'' +
+              ", i='" + i + '\'' +
+              ", f=" + f +
+              ", L=" + L +
+              ", o=" + o +
+              ", c=" + c +
+              ", h=" + h +
+              ", l=" + l +
+              ", v=" + v +
+              ", n=" + n +
+              ", x=" + x +
+              ", q=" + q +
+              ", V=" + V +
+              ", Q=" + Q +
+              '}';
+    }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/MarkPriceUpdateEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/MarkPriceUpdateEvent.java
@@ -11,4 +11,14 @@ public class MarkPriceUpdateEvent extends WebSocketEventMessage {
   public Double p; // Mark price
   public Double r; // Funding rate
   public Long T; // Next funding time
+
+  @Override
+  public String toString() {
+    return "MarkPriceUpdateEvent{" +
+            "s='" + s + '\'' +
+            ", p=" + p +
+            ", r=" + r +
+            ", T=" + T +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/MiniTickerEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/MiniTickerEvent.java
@@ -14,4 +14,17 @@ public class MiniTickerEvent extends WebSocketEventMessage {
   public Double l; // Low price
   public Double v; // Total traded base asset volume
   public Double q; // Total traded quote asset volume
+
+  @Override
+  public String toString() {
+    return "MiniTickerEvent{" +
+            "s='" + s + '\'' +
+            ", c=" + c +
+            ", o=" + o +
+            ", h=" + h +
+            ", l=" + l +
+            ", v=" + v +
+            ", q=" + q +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/TickerEvent.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/TickerEvent.java
@@ -23,4 +23,26 @@ public class TickerEvent extends WebSocketEventMessage {
   public Long F; // First trade ID
   public Long L; // Last trade Id
   public Integer n; // Total number of trades
+
+  @Override
+  public String toString() {
+    return "TickerEvent{" +
+            "s='" + s + '\'' +
+            ", p=" + p +
+            ", P=" + P +
+            ", w=" + w +
+            ", c=" + c +
+            ", Q=" + Q +
+            ", o=" + o +
+            ", h=" + h +
+            ", l=" + l +
+            ", v=" + v +
+            ", q=" + q +
+            ", O=" + O +
+            ", C=" + C +
+            ", F=" + F +
+            ", L=" + L +
+            ", n=" + n +
+            '}';
+  }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/AccountConfigUpdateChannel.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/AccountConfigUpdateChannel.java
@@ -43,6 +43,14 @@ public final class AccountConfigUpdateChannel
 
       public String s; // symbol
       public Integer l; // leverage
+
+      @Override
+      public String toString() {
+        return "AccountConfig{" +
+                "s='" + s + '\'' +
+                ", l=" + l +
+                '}';
+      }
     }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/AccountUpdateChannel.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/AccountUpdateChannel.java
@@ -45,6 +45,15 @@ public final class AccountUpdateChannel
       public String m; // event reason type
       public List<BalanceUpdate> B; // balance updates
       public List<PositionUpdate> P; // position updates
+
+      @Override
+      public String toString() {
+        return "UpdateData{" +
+                "m='" + m + '\'' +
+                ", B=" + B +
+                ", P=" + P +
+                '}';
+      }
     }
   }
 
@@ -54,6 +63,15 @@ public final class AccountUpdateChannel
     public String a; // asset
     public BigDecimal wb; // wallet balance
     public BigDecimal cw; // cross wallet balance
+
+    @Override
+    public String toString() {
+      return "BalanceUpdate{" +
+              "a='" + a + '\'' +
+              ", wb=" + wb +
+              ", cw=" + cw +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -67,5 +85,19 @@ public final class AccountUpdateChannel
     public String mt; // margin type
     public BigDecimal iw; // isolated wallet
     public String ps; // position side
+
+    @Override
+    public String toString() {
+      return "PositionUpdate{" +
+              "s='" + s + '\'' +
+              ", pa=" + pa +
+              ", ep=" + ep +
+              ", cr=" + cr +
+              ", up=" + up +
+              ", mt='" + mt + '\'' +
+              ", iw=" + iw +
+              ", ps='" + ps + '\'' +
+              '}';
+    }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/MarginCallChannel.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/MarginCallChannel.java
@@ -38,6 +38,14 @@ public final class MarginCallChannel
     public Double cw; // transaction time
     public List<PositionForMarginCall> p;
 
+    @Override
+    public String toString() {
+      return "Message{" +
+              "cw=" + cw +
+              ", p=" + p +
+              '}';
+    }
+
     @NotThreadSafe
     public static class PositionForMarginCall {
 
@@ -48,6 +56,19 @@ public final class MarginCallChannel
       public Double mp; // mark price
       public Double up; // unrealized PnL
       public Double mm; // maintenance margin required
+
+      @Override
+      public String toString() {
+        return "PositionForMarginCall{" +
+                "s='" + s + '\'' +
+                ", ps='" + ps + '\'' +
+                ", mt='" + mt + '\'' +
+                ", iw=" + iw +
+                ", mp=" + mp +
+                ", up=" + up +
+                ", mm=" + mm +
+                '}';
+      }
     }
   }
 }

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/OrderUpdateChannel.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/OrderUpdateChannel.java
@@ -37,6 +37,14 @@ public final class OrderUpdateChannel
     public long T; // trasnaction time
     public Order o;
 
+    @Override
+    public String toString() {
+      return "Message{" +
+              "T=" + T +
+              ", o=" + o +
+              '}';
+    }
+
     @NotThreadSafe
     public static class Order {
 
@@ -70,6 +78,42 @@ public final class OrderUpdateChannel
       public Double AP; // activatin price
       public Double cr; // callback rate
       public Double rp; // realized profit
+
+      @Override
+      public String toString() {
+        return "Order{" +
+                "s='" + s + '\'' +
+                ", c='" + c + '\'' +
+                ", S='" + S + '\'' +
+                ", o='" + o + '\'' +
+                ", f='" + f + '\'' +
+                ", q=" + q +
+                ", p=" + p +
+                ", ap=" + ap +
+                ", sp=" + sp +
+                ", x='" + x + '\'' +
+                ", X='" + X + '\'' +
+                ", i=" + i +
+                ", l=" + l +
+                ", z=" + z +
+                ", L=" + L +
+                ", N='" + N + '\'' +
+                ", n='" + n + '\'' +
+                ", T=" + T +
+                ", t=" + t +
+                ", b=" + b +
+                ", a=" + a +
+                ", m=" + m +
+                ", R=" + R +
+                ", wt='" + wt + '\'' +
+                ", ot='" + ot + '\'' +
+                ", ps='" + ps + '\'' +
+                ", cp=" + cp +
+                ", AP=" + AP +
+                ", cr=" + cr +
+                ", rp=" + rp +
+                '}';
+      }
     }
   }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_Account.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_Account.java
@@ -17,4 +17,21 @@ public class _Account {
   public String accountType;
   public List<_AccountBalance> balances;
   public List<String> permissions;
+
+  @Override
+  public String toString() {
+    return "_Account{" +
+            "makerCommission=" + makerCommission +
+            ", takerCommission=" + takerCommission +
+            ", buyerCommission=" + buyerCommission +
+            ", sellerCommission=" + sellerCommission +
+            ", canTrade=" + canTrade +
+            ", canWithdraw=" + canWithdraw +
+            ", canDeposit=" + canDeposit +
+            ", updateTime=" + updateTime +
+            ", accountType='" + accountType + '\'' +
+            ", balances=" + balances +
+            ", permissions=" + permissions +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_AccountBalance.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_AccountBalance.java
@@ -8,4 +8,13 @@ public class _AccountBalance {
   public String asset;
   public String free;
   public String locked;
+
+  @Override
+  public String toString() {
+    return "_AccountBalance{" +
+            "asset='" + asset + '\'' +
+            ", free='" + free + '\'' +
+            ", locked='" + locked + '\'' +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_BookTicker.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_BookTicker.java
@@ -10,4 +10,15 @@ public class _BookTicker {
   public Double bidQty;
   public Double askPrice;
   public Double askQty;
+
+  @Override
+  public String toString() {
+    return "_BookTicker{" +
+            "symbol='" + symbol + '\'' +
+            ", bidPrice=" + bidPrice +
+            ", bidQty=" + bidQty +
+            ", askPrice=" + askPrice +
+            ", askQty=" + askQty +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_Order.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_Order.java
@@ -24,4 +24,29 @@ public class _Order {
   public Boolean isWorking;
   public String origClientOrderId;
   public String origQuoteOrderQty;
+
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "symbol='" + symbol + '\'' +
+            ", orderId=" + orderId +
+            ", orderListId=" + orderListId +
+            ", clientOrderId='" + clientOrderId + '\'' +
+            ", price='" + price + '\'' +
+            ", origQty='" + origQty + '\'' +
+            ", executedQty='" + executedQty + '\'' +
+            ", cummulativeQuoteQty='" + cummulativeQuoteQty + '\'' +
+            ", status='" + status + '\'' +
+            ", timeInForce='" + timeInForce + '\'' +
+            ", type='" + type + '\'' +
+            ", side='" + side + '\'' +
+            ", stopPrice='" + stopPrice + '\'' +
+            ", icebergQty='" + icebergQty + '\'' +
+            ", time=" + time +
+            ", updateTime=" + updateTime +
+            ", isWorking=" + isWorking +
+            ", origClientOrderId='" + origClientOrderId + '\'' +
+            ", origQuoteOrderQty='" + origQuoteOrderQty + '\'' +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_Trade.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/common/_Trade.java
@@ -11,4 +11,16 @@ public class _Trade {
   public Long time;
   public Boolean isBuyerMaker;
   public Boolean isBestMatch;
+
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "id=" + id +
+            ", price=" + price +
+            ", qty=" + qty +
+            ", time=" + time +
+            ", isBuyerMaker=" + isBuyerMaker +
+            ", isBestMatch=" + isBestMatch +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/rest/market/GetDepth.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/rest/market/GetDepth.java
@@ -103,5 +103,14 @@ public final class GetDepth extends MarketRestRequest<Response> {
 
     public List<_OrderBookLevel> bids;
     public List<_OrderBookLevel> asks;
+
+    @Override
+    public String toString() {
+      return "Response{" +
+              "lastUpdateId=" + lastUpdateId +
+              ", bids=" + bids +
+              ", asks=" + asks +
+              '}';
+    }
   }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/rest/market/GetExchangeInfo.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/rest/market/GetExchangeInfo.java
@@ -47,6 +47,13 @@ public final class GetExchangeInfo extends MarketRestRequest<Response> {
   public static final class Response {
 
     public List<MarketDetails> symbols;
+
+    @Override
+    public String toString() {
+      return "Response{" +
+              "symbols=" + symbols +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -66,5 +73,25 @@ public final class GetExchangeInfo extends MarketRestRequest<Response> {
     public Boolean isMarginTradingAllowed;
     public List<String> permissions;
     public List<Map<String, Object>> filters;
+
+    @Override
+    public String toString() {
+      return "MarketDetails{" +
+              "symbol='" + symbol + '\'' +
+              ", status='" + status + '\'' +
+              ", baseAsset='" + baseAsset + '\'' +
+              ", baseAssetPrecision=" + baseAssetPrecision +
+              ", quoteAsset='" + quoteAsset + '\'' +
+              ", quotePrecision=" + quotePrecision +
+              ", quoteAssetPrecision=" + quoteAssetPrecision +
+              ", orderTypes=" + orderTypes +
+              ", icebergAllowed=" + icebergAllowed +
+              ", ocoAllowed=" + ocoAllowed +
+              ", isSpotTradingAllowed=" + isSpotTradingAllowed +
+              ", isMarginTradingAllowed=" + isMarginTradingAllowed +
+              ", permissions=" + permissions +
+              ", filters=" + filters +
+              '}';
+    }
   }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/rest/user/PostListenKey.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/rest/user/PostListenKey.java
@@ -50,5 +50,12 @@ public final class PostListenKey extends UserRestRequest<Response> {
   public static final class Response {
 
     public String listenKey;
+
+    @Override
+    public String toString() {
+      return "Response{" +
+              "listenKey='" + listenKey + '\'' +
+              '}';
+    }
   }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/AggTradeEvent.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/AggTradeEvent.java
@@ -15,4 +15,18 @@ public class AggTradeEvent extends WebSocketEventMessage {
   public Long l; // Last trade ID
   public Long T; // Trade time
   public Boolean m; // Is the buyer the market maker?
+
+  @Override
+  public String toString() {
+    return "AggTradeEvent{" +
+            "s='" + s + '\'' +
+            ", a=" + a +
+            ", p=" + p +
+            ", q=" + q +
+            ", f=" + f +
+            ", l=" + l +
+            ", T=" + T +
+            ", m=" + m +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/BookTickerEvent.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/BookTickerEvent.java
@@ -14,4 +14,17 @@ public class BookTickerEvent extends WebSocketEventMessage {
   public Double B; // best bid qty
   public Double a; // best ask price
   public Double A; // best ask qty
+
+  @Override
+  public String toString() {
+    return "BookTickerEvent{" +
+            "u=" + u +
+            ", T=" + T +
+            ", s='" + s + '\'' +
+            ", b=" + b +
+            ", B=" + B +
+            ", a=" + a +
+            ", A=" + A +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/DepthUpdateEvent.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/DepthUpdateEvent.java
@@ -15,4 +15,16 @@ public class DepthUpdateEvent extends WebSocketEventMessage {
   public long u; // last update Id from last stream
   public List<_OrderBookLevel> b; // Bids to be updated [Price level to be updated, Quantity]
   public List<_OrderBookLevel> a; // Asks to be updated [Price level to be updated, Quantity]
+
+  @Override
+  public String toString() {
+    return "DepthUpdateEvent{" +
+            "T=" + T +
+            ", s='" + s + '\'' +
+            ", U=" + U +
+            ", u=" + u +
+            ", b=" + b +
+            ", a=" + a +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/KlineEvent.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/KlineEvent.java
@@ -10,6 +10,14 @@ public class KlineEvent extends WebSocketEventMessage {
   public String s; // Symbol
   public Candle k;
 
+  @Override
+  public String toString() {
+    return "KlineEvent{" +
+            "s='" + s + '\'' +
+            ", k=" + k +
+            '}';
+  }
+
   @NotThreadSafe
   public static class Candle {
 
@@ -29,5 +37,27 @@ public class KlineEvent extends WebSocketEventMessage {
     public Double q; // Quote asset volume
     public Double V; // Taker buy base asset volume
     public Double Q; // Taker buy quote asset volume
+
+    @Override
+    public String toString() {
+      return "Candle{" +
+              "t=" + t +
+              ", T=" + T +
+              ", s='" + s + '\'' +
+              ", i='" + i + '\'' +
+              ", f=" + f +
+              ", L=" + L +
+              ", o=" + o +
+              ", c=" + c +
+              ", h=" + h +
+              ", l=" + l +
+              ", v=" + v +
+              ", n=" + n +
+              ", x=" + x +
+              ", q=" + q +
+              ", V=" + V +
+              ", Q=" + Q +
+              '}';
+    }
   }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/MarkPriceUpdateEvent.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/MarkPriceUpdateEvent.java
@@ -11,4 +11,14 @@ public class MarkPriceUpdateEvent extends WebSocketEventMessage {
   public Double p; // Mark price
   public Double r; // Funding rate
   public Long T; // Next funding time
+
+  @Override
+  public String toString() {
+    return "MarkPriceUpdateEvent{" +
+            "s='" + s + '\'' +
+            ", p=" + p +
+            ", r=" + r +
+            ", T=" + T +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/MiniTickerEvent.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/MiniTickerEvent.java
@@ -14,4 +14,17 @@ public class MiniTickerEvent extends WebSocketEventMessage {
   public Double l; // Low price
   public Double v; // Total traded base asset volume
   public Double q; // Total traded quote asset volume
+
+  @Override
+  public String toString() {
+    return "MiniTickerEvent{" +
+            "s='" + s + '\'' +
+            ", c=" + c +
+            ", o=" + o +
+            ", h=" + h +
+            ", l=" + l +
+            ", v=" + v +
+            ", q=" + q +
+            '}';
+  }
 }

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/TickerEvent.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/TickerEvent.java
@@ -23,4 +23,26 @@ public class TickerEvent extends WebSocketEventMessage {
   public Long F; // First trade ID
   public Long L; // Last trade Id
   public Integer n; // Total number of trades
+
+  @Override
+  public String toString() {
+    return "TickerEvent{" +
+            "s='" + s + '\'' +
+            ", p=" + p +
+            ", P=" + P +
+            ", w=" + w +
+            ", c=" + c +
+            ", Q=" + Q +
+            ", o=" + o +
+            ", h=" + h +
+            ", l=" + l +
+            ", v=" + v +
+            ", q=" + q +
+            ", O=" + O +
+            ", C=" + C +
+            ", F=" + F +
+            ", L=" + L +
+            ", n=" + n +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Instrument.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Instrument.java
@@ -323,4 +323,95 @@ public class _Instrument {
 
   /** Timestamp. */
   public String timestamp;
+
+  @Override
+  public String toString() {
+    return "_Instrument{" +
+            "symbol='" + symbol + '\'' +
+            ", rootSymbol='" + rootSymbol + '\'' +
+            ", state='" + state + '\'' +
+            ", typ='" + typ + '\'' +
+            ", listing='" + listing + '\'' +
+            ", expiry='" + expiry + '\'' +
+            ", settle='" + settle + '\'' +
+            ", relistInterval='" + relistInterval + '\'' +
+            ", optionStrikePcnt=" + optionStrikePcnt +
+            ", optionStrikeRound=" + optionStrikeRound +
+            ", optionStrikePrice=" + optionStrikePrice +
+            ", optionMultiplier=" + optionMultiplier +
+            ", positionCurrency='" + positionCurrency + '\'' +
+            ", underlying='" + underlying + '\'' +
+            ", quoteCurrency='" + quoteCurrency + '\'' +
+            ", underlyingSymbol='" + underlyingSymbol + '\'' +
+            ", reference='" + reference + '\'' +
+            ", referenceSymbol='" + referenceSymbol + '\'' +
+            ", calcInterval='" + calcInterval + '\'' +
+            ", publishInterval='" + publishInterval + '\'' +
+            ", publishTime='" + publishTime + '\'' +
+            ", maxOrderQty=" + maxOrderQty +
+            ", maxPrice=" + maxPrice +
+            ", lotSize=" + lotSize +
+            ", tickSize=" + tickSize +
+            ", multiplier=" + multiplier +
+            ", settlCurrency='" + settlCurrency + '\'' +
+            ", isQuanto=" + isQuanto +
+            ", isInverse=" + isInverse +
+            ", initMargin=" + initMargin +
+            ", maintMargin=" + maintMargin +
+            ", riskLimit=" + riskLimit +
+            ", riskStep=" + riskStep +
+            ", makerFee=" + makerFee +
+            ", takerFee=" + takerFee +
+            ", settlementFee=" + settlementFee +
+            ", fundingBaseSymbol='" + fundingBaseSymbol + '\'' +
+            ", fundingQuoteSymbol='" + fundingQuoteSymbol + '\'' +
+            ", fundingPremiumSymbol='" + fundingPremiumSymbol + '\'' +
+            ", fundingTimestamp='" + fundingTimestamp + '\'' +
+            ", fundingInterval='" + fundingInterval + '\'' +
+            ", fundingRate=" + fundingRate +
+            ", indicativeFundingRate=" + indicativeFundingRate +
+            ", openingTimestamp='" + openingTimestamp + '\'' +
+            ", closingTimestamp='" + closingTimestamp + '\'' +
+            ", sessionInterval='" + sessionInterval + '\'' +
+            ", prevClosePrice=" + prevClosePrice +
+            ", limitDownPrice=" + limitDownPrice +
+            ", limitUpPrice=" + limitUpPrice +
+            ", prevTotalVolume=" + prevTotalVolume +
+            ", totalVolume=" + totalVolume +
+            ", volume24h=" + volume24h +
+            ", prevTotalTurnover=" + prevTotalTurnover +
+            ", totalTurnover=" + totalTurnover +
+            ", turnover=" + turnover +
+            ", turnover24h=" + turnover24h +
+            ", homeNotional24h=" + homeNotional24h +
+            ", foreignNotional24h=" + foreignNotional24h +
+            ", vwap=" + vwap +
+            ", highPrice=" + highPrice +
+            ", lowPrice=" + lowPrice +
+            ", lastPrice=" + lastPrice +
+            ", lastPriceProtected=" + lastPriceProtected +
+            ", lastTickDirection='" + lastTickDirection + '\'' +
+            ", lastChangePcnt=" + lastChangePcnt +
+            ", bidPrice=" + bidPrice +
+            ", midPrice=" + midPrice +
+            ", askPrice=" + askPrice +
+            ", impactBidPrice=" + impactBidPrice +
+            ", impactMidPrice=" + impactMidPrice +
+            ", impactAskPrice=" + impactAskPrice +
+            ", hasLiquidity=" + hasLiquidity +
+            ", openInterest=" + openInterest +
+            ", openValue=" + openValue +
+            ", fairMethod='" + fairMethod + '\'' +
+            ", fairBasisRate=" + fairBasisRate +
+            ", fairBasis=" + fairBasis +
+            ", fairPrice=" + fairPrice +
+            ", markMethod='" + markMethod + '\'' +
+            ", markPrice=" + markPrice +
+            ", indicativeTaxRate=" + indicativeTaxRate +
+            ", indicativeSettlePrice=" + indicativeSettlePrice +
+            ", optionUnderlyingPrice=" + optionUnderlyingPrice +
+            ", settledPrice=" + settledPrice +
+            ", timestamp='" + timestamp + '\'' +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_LiquidationOrder.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_LiquidationOrder.java
@@ -10,4 +10,15 @@ public class _LiquidationOrder {
   public String side;
   public Double price;
   public Double leavesQty;
+
+  @Override
+  public String toString() {
+    return "_LiquidationOrder{" +
+            "orderID='" + orderID + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", side='" + side + '\'' +
+            ", price=" + price +
+            ", leavesQty=" + leavesQty +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Margin.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Margin.java
@@ -18,4 +18,23 @@ public class _Margin {
   public Long availableMargin;
   public Long withdrawableMargin;
   public String timestamp;
+
+  @Override
+  public String toString() {
+    return "_Margin{" +
+            "account=" + account +
+            ", currency='" + currency + '\'' +
+            ", BitmexSatoshi=" + BitmexSatoshi +
+            ", initMargin=" + initMargin +
+            ", maintMargin=" + maintMargin +
+            ", realisedPnl=" + realisedPnl +
+            ", unrealisedPnl=" + unrealisedPnl +
+            ", walletBalance=" + walletBalance +
+            ", marginBalance=" + marginBalance +
+            ", marginLeverage=" + marginLeverage +
+            ", availableMargin=" + availableMargin +
+            ", withdrawableMargin=" + withdrawableMargin +
+            ", timestamp='" + timestamp + '\'' +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_MarketStats.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_MarketStats.java
@@ -11,4 +11,16 @@ public class _MarketStats {
   public Double turnover24h;
   public Double openInterest;
   public Double openValue;
+
+  @Override
+  public String toString() {
+    return "_MarketStats{" +
+            "rootSymbol='" + rootSymbol + '\'' +
+            ", currency='" + currency + '\'' +
+            ", volume24h=" + volume24h +
+            ", turnover24h=" + turnover24h +
+            ", openInterest=" + openInterest +
+            ", openValue=" + openValue +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Order.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Order.java
@@ -24,4 +24,29 @@ public class _Order {
   public String transactTime;
   public String timestamp;
   public String error;
+
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "orderID='" + orderID + '\'' +
+            ", clOrdID='" + clOrdID + '\'' +
+            ", account=" + account +
+            ", symbol='" + symbol + '\'' +
+            ", side='" + side + '\'' +
+            ", orderQty=" + orderQty +
+            ", price=" + price +
+            ", currency='" + currency + '\'' +
+            ", settlCurrency='" + settlCurrency + '\'' +
+            ", ordType='" + ordType + '\'' +
+            ", timeInForce='" + timeInForce + '\'' +
+            ", execInst='" + execInst + '\'' +
+            ", ordStatus='" + ordStatus + '\'' +
+            ", leavesQty=" + leavesQty +
+            ", cumQty=" + cumQty +
+            ", avgPx=" + avgPx +
+            ", transactTime='" + transactTime + '\'' +
+            ", timestamp='" + timestamp + '\'' +
+            ", error='" + error + '\'' +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_OrderBookLevel.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_OrderBookLevel.java
@@ -10,4 +10,15 @@ public class _OrderBookLevel {
   public String side;
   public Double size;
   public Double price;
+
+  @Override
+  public String toString() {
+    return "_OrderBookLevel{" +
+            "symbol='" + symbol + '\'' +
+            ", id=" + id +
+            ", side='" + side + '\'' +
+            ", size=" + size +
+            ", price=" + price +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Position.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Position.java
@@ -84,4 +84,89 @@ public class _Position {
   public String timestamp;
   public Double lastPrice;
   public Long lastValue;
+
+  @Override
+  public String toString() {
+    return "_Position{" +
+            "account=" + account +
+            ", symbol='" + symbol + '\'' +
+            ", currency='" + currency + '\'' +
+            ", underlying='" + underlying + '\'' +
+            ", quoteCurrency='" + quoteCurrency + '\'' +
+            ", commission=" + commission +
+            ", initMarginReq=" + initMarginReq +
+            ", maintMarginReq=" + maintMarginReq +
+            ", riskLimit=" + riskLimit +
+            ", leverage=" + leverage +
+            ", crossMargin=" + crossMargin +
+            ", deleveragePercentile=" + deleveragePercentile +
+            ", rebalancedPnl=" + rebalancedPnl +
+            ", prevRealisedPnl=" + prevRealisedPnl +
+            ", prevUnrealisedPnl=" + prevUnrealisedPnl +
+            ", prevClosePrice=" + prevClosePrice +
+            ", openingTimestamp='" + openingTimestamp + '\'' +
+            ", openingQty=" + openingQty +
+            ", openingCost=" + openingCost +
+            ", openingComm=" + openingComm +
+            ", openOrderBuyQty=" + openOrderBuyQty +
+            ", openOrderBuyCost=" + openOrderBuyCost +
+            ", openOrderBuyPremium=" + openOrderBuyPremium +
+            ", openOrderSellQty=" + openOrderSellQty +
+            ", openOrderSellCost=" + openOrderSellCost +
+            ", openOrderSellPremium=" + openOrderSellPremium +
+            ", execBuyQty=" + execBuyQty +
+            ", execBuyCost=" + execBuyCost +
+            ", execSellQty=" + execSellQty +
+            ", execSellCost=" + execSellCost +
+            ", execQty=" + execQty +
+            ", execCost=" + execCost +
+            ", execComm=" + execComm +
+            ", currentTimestamp='" + currentTimestamp + '\'' +
+            ", currentQty=" + currentQty +
+            ", currentCost=" + currentCost +
+            ", currentComm=" + currentComm +
+            ", realisedCost=" + realisedCost +
+            ", unrealisedCost=" + unrealisedCost +
+            ", grossOpenCost=" + grossOpenCost +
+            ", grossOpenPremium=" + grossOpenPremium +
+            ", grossExecCost=" + grossExecCost +
+            ", isOpen=" + isOpen +
+            ", markPrice=" + markPrice +
+            ", markValue=" + markValue +
+            ", riskValue=" + riskValue +
+            ", homeNotional=" + homeNotional +
+            ", foreignNotional=" + foreignNotional +
+            ", posCost=" + posCost +
+            ", posCost2=" + posCost2 +
+            ", posCross=" + posCross +
+            ", posInit=" + posInit +
+            ", posComm=" + posComm +
+            ", posLoss=" + posLoss +
+            ", posMargin=" + posMargin +
+            ", posMaint=" + posMaint +
+            ", posAllowance=" + posAllowance +
+            ", taxableMargin=" + taxableMargin +
+            ", initMargin=" + initMargin +
+            ", maintMargin=" + maintMargin +
+            ", sessionMargin=" + sessionMargin +
+            ", targetExcessMargin=" + targetExcessMargin +
+            ", varMargin=" + varMargin +
+            ", realisedGrossPnl=" + realisedGrossPnl +
+            ", realisedTax=" + realisedTax +
+            ", realisedPnl=" + realisedPnl +
+            ", unrealisedGrossPnl=" + unrealisedGrossPnl +
+            ", unrealisedPnl=" + unrealisedPnl +
+            ", unrealisedPnlPcnt=" + unrealisedPnlPcnt +
+            ", unrealisedRoePcnt=" + unrealisedRoePcnt +
+            ", avgCostPrice=" + avgCostPrice +
+            ", avgEntryPrice=" + avgEntryPrice +
+            ", breakEvenPrice=" + breakEvenPrice +
+            ", marginCallPrice=" + marginCallPrice +
+            ", liquidationPrice=" + liquidationPrice +
+            ", bankruptPrice=" + bankruptPrice +
+            ", timestamp='" + timestamp + '\'' +
+            ", lastPrice=" + lastPrice +
+            ", lastValue=" + lastValue +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Quote.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Quote.java
@@ -11,4 +11,16 @@ public class _Quote {
   public Double bidPrice;
   public Double askSize;
   public Double askPrice;
+
+  @Override
+  public String toString() {
+    return "_Quote{" +
+            "timestamp='" + timestamp + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", bidSize=" + bidSize +
+            ", bidPrice=" + bidPrice +
+            ", askSize=" + askSize +
+            ", askPrice=" + askPrice +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Trade.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_Trade.java
@@ -15,4 +15,20 @@ public class _Trade {
   public Double grossValue;
   public Double homeNotional;
   public Double foreignNotional;
+
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "timestamp='" + timestamp + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", side='" + side + '\'' +
+            ", size=" + size +
+            ", price=" + price +
+            ", tickDirection='" + tickDirection + '\'' +
+            ", trdMatchID='" + trdMatchID + '\'' +
+            ", grossValue=" + grossValue +
+            ", homeNotional=" + homeNotional +
+            ", foreignNotional=" + foreignNotional +
+            '}';
+  }
 }

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_TradeBin.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/common/_TradeBin.java
@@ -18,4 +18,23 @@ public class _TradeBin {
   public Double turnover;
   public Double homeNotional;
   public Double foreignNotional;
+
+  @Override
+  public String toString() {
+    return "_TradeBin{" +
+            "timestamp='" + timestamp + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", open=" + open +
+            ", high=" + high +
+            ", low=" + low +
+            ", close=" + close +
+            ", trades=" + trades +
+            ", volume=" + volume +
+            ", vwap=" + vwap +
+            ", lastSize=" + lastSize +
+            ", turnover=" + turnover +
+            ", homeNotional=" + homeNotional +
+            ", foreignNotional=" + foreignNotional +
+            '}';
+  }
 }

--- a/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/common/_OrderBook.java
+++ b/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/common/_OrderBook.java
@@ -10,4 +10,14 @@ public class _OrderBook {
   public List<_OrderBookLevel> bids;
   public Long microtimestamp;
   public Long timestamp;
+
+  @Override
+  public String toString() {
+    return "_OrderBook{" +
+            "asks=" + asks +
+            ", bids=" + bids +
+            ", microtimestamp=" + microtimestamp +
+            ", timestamp=" + timestamp +
+            '}';
+  }
 }

--- a/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/websocket/market/DiffOrderBookChannel.java
+++ b/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/websocket/market/DiffOrderBookChannel.java
@@ -47,5 +47,15 @@ public final class DiffOrderBookChannel
     public Long microtimestamp;
     public List<_OrderBookLevel> bids;
     public List<_OrderBookLevel> asks;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "timestamp=" + timestamp +
+              ", microtimestamp=" + microtimestamp +
+              ", bids=" + bids +
+              ", asks=" + asks +
+              '}';
+    }
   }
 }

--- a/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/websocket/market/LiveTradesChannel.java
+++ b/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/websocket/market/LiveTradesChannel.java
@@ -51,5 +51,21 @@ public final class LiveTradesChannel
     public Long microtimestamp;
     public Long buy_order_id;
     public Long sell_order_id;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "id=" + id +
+              ", amount=" + amount +
+              ", amount_str='" + amount_str + '\'' +
+              ", price=" + price +
+              ", price_str='" + price_str + '\'' +
+              ", type=" + type +
+              ", timestamp=" + timestamp +
+              ", microtimestamp=" + microtimestamp +
+              ", buy_order_id=" + buy_order_id +
+              ", sell_order_id=" + sell_order_id +
+              '}';
+    }
   }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_AccountRatio.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_AccountRatio.java
@@ -9,4 +9,14 @@ public class _AccountRatio {
   public double buy_ratio;
   public double sell_ratio;
   public double timestamp;
+
+  @Override
+  public String toString() {
+    return "_AccountRatio{" +
+            "symbol='" + symbol + '\'' +
+            ", buy_ratio=" + buy_ratio +
+            ", sell_ratio=" + sell_ratio +
+            ", timestamp=" + timestamp +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_ApiKey.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_ApiKey.java
@@ -16,4 +16,20 @@ public class _ApiKey {
   public String created_at;
   public String expired_at;
   public boolean read_only;
+
+  @Override
+  public String toString() {
+    return "_ApiKey{" +
+            "api_key='" + api_key + '\'' +
+            ", type='" + type + '\'' +
+            ", user_id=" + user_id +
+            ", inviter_id=" + inviter_id +
+            ", ips=" + ips +
+            ", note='" + note + '\'' +
+            ", permissions=" + permissions +
+            ", created_at='" + created_at + '\'' +
+            ", expired_at='" + expired_at + '\'' +
+            ", read_only=" + read_only +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Kline.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Kline.java
@@ -14,4 +14,19 @@ public class _Kline {
   public double close;
   public double volume;
   public double turnover;
+
+  @Override
+  public String toString() {
+    return "_Kline{" +
+            "symbol='" + symbol + '\'' +
+            ", interval='" + interval + '\'' +
+            ", open_time=" + open_time +
+            ", open=" + open +
+            ", high=" + high +
+            ", low=" + low +
+            ", close=" + close +
+            ", volume=" + volume +
+            ", turnover=" + turnover +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Leverage.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Leverage.java
@@ -6,4 +6,11 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class _Leverage {
 
   public double leverage;
+
+  @Override
+  public String toString() {
+    return "_Leverage{" +
+            "leverage=" + leverage +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_LeverageFilter.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_LeverageFilter.java
@@ -8,4 +8,13 @@ public class _LeverageFilter {
   public double min_leverage;
   public double max_leverage;
   public double leverage_step;
+
+  @Override
+  public String toString() {
+    return "_LeverageFilter{" +
+            "min_leverage=" + min_leverage +
+            ", max_leverage=" + max_leverage +
+            ", leverage_step=" + leverage_step +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_LotSizeFilter.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_LotSizeFilter.java
@@ -8,4 +8,13 @@ public class _LotSizeFilter {
   public double max_trading_qty;
   public double min_trading_qty;
   public double qty_step;
+
+  @Override
+  public String toString() {
+    return "_LotSizeFilter{" +
+            "max_trading_qty=" + max_trading_qty +
+            ", min_trading_qty=" + min_trading_qty +
+            ", qty_step=" + qty_step +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Order.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Order.java
@@ -24,4 +24,29 @@ public class _Order {
   public String order_link_id;
   public String created_at;
   public String updated_at;
+
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "user_id=" + user_id +
+            ", order_id='" + order_id + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", side='" + side + '\'' +
+            ", order_type='" + order_type + '\'' +
+            ", price=" + price +
+            ", qty=" + qty +
+            ", time_in_force='" + time_in_force + '\'' +
+            ", order_status='" + order_status + '\'' +
+            ", last_exec_time='" + last_exec_time + '\'' +
+            ", last_exec_price='" + last_exec_price + '\'' +
+            ", leaves_qty=" + leaves_qty +
+            ", cum_exec_qty=" + cum_exec_qty +
+            ", cum_exec_value=" + cum_exec_value +
+            ", cum_exec_fee=" + cum_exec_fee +
+            ", reject_reason='" + reject_reason + '\'' +
+            ", order_link_id='" + order_link_id + '\'' +
+            ", created_at='" + created_at + '\'' +
+            ", updated_at='" + updated_at + '\'' +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_OrderBookLevel.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_OrderBookLevel.java
@@ -9,4 +9,14 @@ public class _OrderBookLevel {
   public double price;
   public int size;
   public String side;
+
+  @Override
+  public String toString() {
+    return "_OrderBookLevel{" +
+            "symbol='" + symbol + '\'' +
+            ", price=" + price +
+            ", size=" + size +
+            ", side='" + side + '\'' +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_OrderCancelAll.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_OrderCancelAll.java
@@ -22,4 +22,27 @@ public class _OrderCancelAll {
   public String updated_at;
   public String cross_status;
   public long cross_seq;
+
+  @Override
+  public String toString() {
+    return "_OrderCancelAll{" +
+            "clOrdID='" + clOrdID + '\'' +
+            ", user_id=" + user_id +
+            ", symbol='" + symbol + '\'' +
+            ", side='" + side + '\'' +
+            ", order_type='" + order_type + '\'' +
+            ", price=" + price +
+            ", qty=" + qty +
+            ", time_in_force='" + time_in_force + '\'' +
+            ", create_type='" + create_type + '\'' +
+            ", cancel_type='" + cancel_type + '\'' +
+            ", order_status='" + order_status + '\'' +
+            ", leaves_qty=" + leaves_qty +
+            ", leaves_value=" + leaves_value +
+            ", created_at='" + created_at + '\'' +
+            ", updated_at='" + updated_at + '\'' +
+            ", cross_status='" + cross_status + '\'' +
+            ", cross_seq=" + cross_seq +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Position.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Position.java
@@ -37,4 +37,42 @@ public class _Position {
   public long position_seq;
   public String created_at;
   public String updated_at;
+
+  @Override
+  public String toString() {
+    return "_Position{" +
+            "id=" + id +
+            ", user_id=" + user_id +
+            ", risk_id=" + risk_id +
+            ", symbol='" + symbol + '\'' +
+            ", side='" + side + '\'' +
+            ", size=" + size +
+            ", position_value=" + position_value +
+            ", entry_price=" + entry_price +
+            ", is_isolated=" + is_isolated +
+            ", auto_add_margin=" + auto_add_margin +
+            ", leverage=" + leverage +
+            ", effective_leverage=" + effective_leverage +
+            ", position_margin=" + position_margin +
+            ", liq_price=" + liq_price +
+            ", bust_price=" + bust_price +
+            ", occ_closing_fee=" + occ_closing_fee +
+            ", occ_funding_fee=" + occ_funding_fee +
+            ", take_profit=" + take_profit +
+            ", stop_loss=" + stop_loss +
+            ", trailing_stop=" + trailing_stop +
+            ", position_status='" + position_status + '\'' +
+            ", deleverage_indicator=" + deleverage_indicator +
+            ", oc_calc_data='" + oc_calc_data + '\'' +
+            ", order_margin=" + order_margin +
+            ", wallet_balance=" + wallet_balance +
+            ", realised_pnl=" + realised_pnl +
+            ", unrealised_pnl=" + unrealised_pnl +
+            ", cum_realised_pnl=" + cum_realised_pnl +
+            ", cross_seq=" + cross_seq +
+            ", position_seq=" + position_seq +
+            ", created_at='" + created_at + '\'' +
+            ", updated_at='" + updated_at + '\'' +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_PriceFilter.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_PriceFilter.java
@@ -8,4 +8,13 @@ public class _PriceFilter {
   public double min_price;
   public double max_price;
   public double tick_size;
+
+  @Override
+  public String toString() {
+    return "_PriceFilter{" +
+            "min_price=" + min_price +
+            ", max_price=" + max_price +
+            ", tick_size=" + tick_size +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Symbol.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Symbol.java
@@ -14,4 +14,19 @@ public class _Symbol {
   public _LeverageFilter leverage_filter;
   public _PriceFilter price_filter;
   public _LotSizeFilter lot_size_filter;
+
+  @Override
+  public String toString() {
+    return "_Symbol{" +
+            "name='" + name + '\'' +
+            ", base_currency='" + base_currency + '\'' +
+            ", quote_currency='" + quote_currency + '\'' +
+            ", price_scale=" + price_scale +
+            ", taker_fee=" + taker_fee +
+            ", maker_fee=" + maker_fee +
+            ", leverage_filter=" + leverage_filter +
+            ", price_filter=" + price_filter +
+            ", lot_size_filter=" + lot_size_filter +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Ticker.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_Ticker.java
@@ -28,4 +28,33 @@ public class _Ticker {
   public double predicted_funding_rate;
   public String next_funding_time;
   public int countdown_hour;
+
+  @Override
+  public String toString() {
+    return "_Ticker{" +
+            "symbol='" + symbol + '\'' +
+            ", bid_price='" + bid_price + '\'' +
+            ", ask_price='" + ask_price + '\'' +
+            ", last_price='" + last_price + '\'' +
+            ", last_tick_direction='" + last_tick_direction + '\'' +
+            ", prev_price_24h='" + prev_price_24h + '\'' +
+            ", price_24h_pcnt='" + price_24h_pcnt + '\'' +
+            ", high_price_24h='" + high_price_24h + '\'' +
+            ", low_price_24h='" + low_price_24h + '\'' +
+            ", prev_price_1h='" + prev_price_1h + '\'' +
+            ", price_1h_pcnt='" + price_1h_pcnt + '\'' +
+            ", mark_price='" + mark_price + '\'' +
+            ", index_price='" + index_price + '\'' +
+            ", open_interest=" + open_interest +
+            ", open_value=" + open_value +
+            ", total_turnover=" + total_turnover +
+            ", turnover_24h=" + turnover_24h +
+            ", total_volume=" + total_volume +
+            ", volume_24h=" + volume_24h +
+            ", funding_rate=" + funding_rate +
+            ", predicted_funding_rate=" + predicted_funding_rate +
+            ", next_funding_time='" + next_funding_time + '\'' +
+            ", countdown_hour=" + countdown_hour +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_UserTrade.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_UserTrade.java
@@ -26,4 +26,31 @@ public class _UserTrade {
   public String symbol;
   public Long user_id;
   public Long trade_time_ms;
+
+  @Override
+  public String toString() {
+    return "_UserTrade{" +
+            "closed_size=" + closed_size +
+            ", cross_seq=" + cross_seq +
+            ", exec_fee='" + exec_fee + '\'' +
+            ", exec_id='" + exec_id + '\'' +
+            ", exec_price='" + exec_price + '\'' +
+            ", exec_qty=" + exec_qty +
+            ", exec_type='" + exec_type + '\'' +
+            ", exec_value='" + exec_value + '\'' +
+            ", fee_rate='" + fee_rate + '\'' +
+            ", last_liquidity_ind='" + last_liquidity_ind + '\'' +
+            ", leaves_qty=" + leaves_qty +
+            ", nth_fill=" + nth_fill +
+            ", order_id='" + order_id + '\'' +
+            ", order_link_id='" + order_link_id + '\'' +
+            ", order_price='" + order_price + '\'' +
+            ", order_qty=" + order_qty +
+            ", order_type='" + order_type + '\'' +
+            ", side='" + side + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", user_id=" + user_id +
+            ", trade_time_ms=" + trade_time_ms +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_UserTradingRecords.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_UserTradingRecords.java
@@ -7,4 +7,11 @@ import java.util.List;
 public class _UserTradingRecords {
 
   public List<_UserTrade> trade_list;
+
+  @Override
+  public String toString() {
+    return "_UserTradingRecords{" +
+            "trade_list=" + trade_list +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_WalletBalance.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_WalletBalance.java
@@ -18,4 +18,23 @@ public class _WalletBalance {
   public double cum_realised_pnl;
   public double given_cash;
   public double service_cash;
+
+  @Override
+  public String toString() {
+    return "_WalletBalance{" +
+            "equity=" + equity +
+            ", available_balance=" + available_balance +
+            ", used_margin=" + used_margin +
+            ", order_margin=" + order_margin +
+            ", position_margin=" + position_margin +
+            ", occ_closing_fee=" + occ_closing_fee +
+            ", occ_funding_fee=" + occ_funding_fee +
+            ", wallet_balance=" + wallet_balance +
+            ", realised_pnl=" + realised_pnl +
+            ", unrealised_pnl=" + unrealised_pnl +
+            ", cum_realised_pnl=" + cum_realised_pnl +
+            ", given_cash=" + given_cash +
+            ", service_cash=" + service_cash +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_WalletFundRecord.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/common/_WalletFundRecord.java
@@ -16,4 +16,21 @@ public class _WalletFundRecord {
   public String wallet_balance;
   public String exec_time;
   public Long cross_seq;
+
+  @Override
+  public String toString() {
+    return "_WalletFundRecord{" +
+            "id=" + id +
+            ", user_id=" + user_id +
+            ", coin='" + coin + '\'' +
+            ", wallet_id=" + wallet_id +
+            ", type='" + type + '\'' +
+            ", amount='" + amount + '\'' +
+            ", tx_id='" + tx_id + '\'' +
+            ", address='" + address + '\'' +
+            ", wallet_balance='" + wallet_balance + '\'' +
+            ", exec_time='" + exec_time + '\'' +
+            ", cross_seq=" + cross_seq +
+            '}';
+  }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/rest/user/GetPositionList.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/rest/user/GetPositionList.java
@@ -56,5 +56,13 @@ public final class GetPositionList extends UserRestRequest<Response> {
 
     public boolean is_valid;
     public _Position data;
+
+    @Override
+    public String toString() {
+      return "Result{" +
+              "is_valid=" + is_valid +
+              ", data=" + data +
+              '}';
+    }
   }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/InstrumentInfoChannel.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/InstrumentInfoChannel.java
@@ -40,6 +40,16 @@ public final class InstrumentInfoChannel extends WebSocketChannel<InstrumentInfo
     public InstrumentInfoData data;
     public Long cross_seq;
     public Long timestamp_e6;
+
+    @Override
+    public String toString() {
+      return "Message{" +
+              "type='" + type + '\'' +
+              ", data=" + data +
+              ", cross_seq=" + cross_seq +
+              ", timestamp_e6=" + timestamp_e6 +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -48,6 +58,15 @@ public final class InstrumentInfoChannel extends WebSocketChannel<InstrumentInfo
     public List<InstrumentInfo> delete;
     public List<InstrumentInfo> update;
     public List<InstrumentInfo> insert;
+
+    @Override
+    public String toString() {
+      return "InstrumentInfoData{" +
+              "delete=" + delete +
+              ", update=" + update +
+              ", insert=" + insert +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -76,5 +95,34 @@ public final class InstrumentInfoChannel extends WebSocketChannel<InstrumentInfo
     public String updated_at; // Update time
     public String next_funding_time; // Next settlement time of capital cost
     public Long countdown_hour; // Countdown of settlement capital cost
+
+    @Override
+    public String toString() {
+      return "InstrumentInfo{" +
+              "symbol='" + symbol + '\'' +
+              ", last_price_e4=" + last_price_e4 +
+              ", last_tick_direction='" + last_tick_direction + '\'' +
+              ", prev_price_24h_e4=" + prev_price_24h_e4 +
+              ", price_24h_pcnt_e6=" + price_24h_pcnt_e6 +
+              ", high_price_24h_e4=" + high_price_24h_e4 +
+              ", low_price_24h_e4=" + low_price_24h_e4 +
+              ", prev_price_1h_e4=" + prev_price_1h_e4 +
+              ", price_1h_pcnt_e6=" + price_1h_pcnt_e6 +
+              ", mark_price_e4=" + mark_price_e4 +
+              ", index_price_e4=" + index_price_e4 +
+              ", open_interest=" + open_interest +
+              ", open_value_e8=" + open_value_e8 +
+              ", total_turnover_e8=" + total_turnover_e8 +
+              ", turnover_24h_e8=" + turnover_24h_e8 +
+              ", total_volume=" + total_volume +
+              ", volume_24h=" + volume_24h +
+              ", predicted_funding_rate_e6=" + predicted_funding_rate_e6 +
+              ", cross_seq=" + cross_seq +
+              ", created_at='" + created_at + '\'' +
+              ", updated_at='" + updated_at + '\'' +
+              ", next_funding_time='" + next_funding_time + '\'' +
+              ", countdown_hour=" + countdown_hour +
+              '}';
+    }
   }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/KlineV2Channel.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/KlineV2Channel.java
@@ -38,6 +38,14 @@ public final class KlineV2Channel extends WebSocketChannel<KlineV2Channel.Id, Kl
 
     public List<KlineV2> data;
     public Long timestamp_e6;
+
+    @Override
+    public String toString() {
+      return "Message{" +
+              "data=" + data +
+              ", timestamp_e6=" + timestamp_e6 +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -54,5 +62,22 @@ public final class KlineV2Channel extends WebSocketChannel<KlineV2Channel.Id, Kl
     public Boolean confirm; // Is confirm
     public Long cross_seq; // Cross sequence (internal value)
     public Long timestamp; // End timestamp point for result, in seconds
+
+    @Override
+    public String toString() {
+      return "KlineV2{" +
+              "start=" + start +
+              ", end=" + end +
+              ", open=" + open +
+              ", close=" + close +
+              ", high=" + high +
+              ", low=" + low +
+              ", volume=" + volume +
+              ", turnover=" + turnover +
+              ", confirm=" + confirm +
+              ", cross_seq=" + cross_seq +
+              ", timestamp=" + timestamp +
+              '}';
+    }
   }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/TradeChannel.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/market/TradeChannel.java
@@ -37,6 +37,13 @@ public final class TradeChannel extends WebSocketChannel<TradeChannel.Id, TradeC
   public static final class Message extends WebSocketTopicMessage {
 
     public List<Trade> data;
+
+    @Override
+    public String toString() {
+      return "Message{" +
+              "data=" + data +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -51,5 +58,20 @@ public final class TradeChannel extends WebSocketChannel<TradeChannel.Id, TradeC
     public String tick_direction; // Direction of price change
     public String trade_id; // Trade ID
     public Long cross_seq; // Cross sequence
+
+    @Override
+    public String toString() {
+      return "Trade{" +
+              "timestamp='" + timestamp + '\'' +
+              ", trade_time_ms=" + trade_time_ms +
+              ", symbol='" + symbol + '\'' +
+              ", side='" + side + '\'' +
+              ", size=" + size +
+              ", price=" + price +
+              ", tick_direction='" + tick_direction + '\'' +
+              ", trade_id='" + trade_id + '\'' +
+              ", cross_seq=" + cross_seq +
+              '}';
+    }
   }
 }

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/user/OrderChannel.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/user/OrderChannel.java
@@ -36,5 +36,12 @@ public final class OrderChannel extends WebSocketChannel<OrderChannel.Id, OrderC
   public static final class Message extends WebSocketTopicMessage {
 
     public List<_Order> data;
+
+    @Override
+    public String toString() {
+      return "Message{" +
+              "data=" + data +
+              '}';
+    }
   }
 }

--- a/coinbasepro-api/src/main/java/io/contek/invoker/coinbasepro/api/websocket/market/Level2Channel.java
+++ b/coinbasepro-api/src/main/java/io/contek/invoker/coinbasepro/api/websocket/market/Level2Channel.java
@@ -42,6 +42,14 @@ public final class Level2Channel extends WebSocketChannel<Level2Channel.Id, Leve
 
     public String time;
     public List<L2UpdateChange> changes;
+
+    @Override
+    public String toString() {
+      return "L2UpdateMessage{" +
+              "time='" + time + '\'' +
+              ", changes=" + changes +
+              '}';
+    }
   }
 
   @NotThreadSafe
@@ -52,6 +60,14 @@ public final class Level2Channel extends WebSocketChannel<Level2Channel.Id, Leve
 
     public List<SnapshotLevel> bids;
     public List<SnapshotLevel> asks;
+
+    @Override
+    public String toString() {
+      return "SnapshotMessage{" +
+              "bids=" + bids +
+              ", asks=" + asks +
+              '}';
+    }
   }
 
   @NotThreadSafe

--- a/coinbasepro-api/src/main/java/io/contek/invoker/coinbasepro/api/websocket/market/MatchesChannel.java
+++ b/coinbasepro-api/src/main/java/io/contek/invoker/coinbasepro/api/websocket/market/MatchesChannel.java
@@ -44,5 +44,19 @@ public final class MatchesChannel
     public Double size;
     public Double price;
     public String side;
+
+    @Override
+    public String toString() {
+      return "Message{" +
+              "trade_id=" + trade_id +
+              ", sequence=" + sequence +
+              ", maker_order_id='" + maker_order_id + '\'' +
+              ", taker_order_id='" + taker_order_id + '\'' +
+              ", time='" + time + '\'' +
+              ", size=" + size +
+              ", price=" + price +
+              ", side='" + side + '\'' +
+              '}';
+    }
   }
 }

--- a/commons/src/main/java/io/contek/invoker/commons/rest/RestMediaType.java
+++ b/commons/src/main/java/io/contek/invoker/commons/rest/RestMediaType.java
@@ -1,6 +1,7 @@
 package io.contek.invoker.commons.rest;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import okhttp3.MediaType;
 
 import javax.annotation.concurrent.Immutable;
@@ -17,7 +18,13 @@ public enum RestMediaType {
       requireNonNull(MediaType.parse("application/x-www-form-urlencoded")),
       RestMediaType::toFormString);
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson;
+
+  static {
+    GsonBuilder builder = new GsonBuilder();
+    builder.serializeNulls();
+    gson = builder.create();
+  }
 
   private final MediaType value;
   private final Function<RestParams, String> composer;

--- a/commons/src/main/java/io/contek/invoker/commons/rest/RestParams.java
+++ b/commons/src/main/java/io/contek/invoker/commons/rest/RestParams.java
@@ -5,9 +5,12 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -18,10 +21,10 @@ public final class RestParams {
 
   private static final RestParams EMPTY = RestParams.newBuilder().build();
 
-  private final ImmutableMap<String, Object> values;
+  private final Map<String, Object> values;
 
-  private RestParams(ImmutableMap<String, Object> values) {
-    this.values = values;
+  private RestParams(Map<String, Object> values) {
+    this.values = Collections.unmodifiableMap(new HashMap<>(values));
   }
 
   public static Builder newBuilder() {
@@ -40,7 +43,7 @@ public final class RestParams {
     return values.isEmpty();
   }
 
-  public ImmutableMap<String, Object> getValues() {
+  public Map<String, Object> getValues() {
     return values;
   }
 
@@ -61,7 +64,7 @@ public final class RestParams {
   @NotThreadSafe
   public static final class Builder {
 
-    private final Map<String, Object> values = new LinkedHashMap<>();
+    private final Map<String, Object> values = new HashMap<>();
 
     private Builder() {}
 
@@ -79,7 +82,25 @@ public final class RestParams {
       return this;
     }
 
-    public Builder add(String key, String value) {
+    public Builder add(String key, @Nullable Long value) {
+      values.put(key, value);
+      return this;
+    }
+
+    public Builder add(String key, @Nullable Double value) {
+      if (value == null) {
+        values.put(key, null);
+        return this;
+      }
+      return add(key, BigDecimal.valueOf(value).toPlainString());
+    }
+
+    public Builder add(String key, @Nullable Boolean value) {
+      values.put(key, value);
+      return this;
+    }
+
+    public Builder add(String key, @Nullable String value) {
       values.put(key, value);
       return this;
     }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_AccountSummary.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_AccountSummary.java
@@ -46,4 +46,50 @@ public class _AccountSummary {
   public double balance;
   public double projected_initial_margin;
   public String deposit_address;
+
+  @Override
+  public String toString() {
+    return "_AccountSummary{" +
+            "options_gamma=" + options_gamma +
+            ", projected_maintenance_margin=" + projected_maintenance_margin +
+            ", system_name='" + system_name + '\'' +
+            ", margin_balance=" + margin_balance +
+            ", tfa_enabled=" + tfa_enabled +
+            ", options_value=" + options_value +
+            ", username='" + username + '\'' +
+            ", limits=" + limits +
+            ", equity=" + equity +
+            ", futures_pl=" + futures_pl +
+            ", fees=" + fees +
+            ", options_session_upl=" + options_session_upl +
+            ", id=" + id +
+            ", options_vega=" + options_vega +
+            ", referrer_id='" + referrer_id + '\'' +
+            ", currency='" + currency + '\'' +
+            ", login_enabled=" + login_enabled +
+            ", type='" + type + '\'' +
+            ", futures_session_rpl=" + futures_session_rpl +
+            ", options_theta=" + options_theta +
+            ", portfolio_margining_enabled=" + portfolio_margining_enabled +
+            ", projected_delta_total=" + projected_delta_total +
+            ", session_rpl=" + session_rpl +
+            ", delta_total=" + delta_total +
+            ", options_pl=" + options_pl +
+            ", available_withdrawal_funds=" + available_withdrawal_funds +
+            ", maintenance_margin=" + maintenance_margin +
+            ", initial_margin=" + initial_margin +
+            ", interuser_transfers_enabled=" + interuser_transfers_enabled +
+            ", futures_session_upl=" + futures_session_upl +
+            ", options_session_rpl=" + options_session_rpl +
+            ", available_funds=" + available_funds +
+            ", email='" + email + '\'' +
+            ", creation_timestamp=" + creation_timestamp +
+            ", session_upl=" + session_upl +
+            ", total_pl=" + total_pl +
+            ", options_delta=" + options_delta +
+            ", balance=" + balance +
+            ", projected_initial_margin=" + projected_initial_margin +
+            ", deposit_address='" + deposit_address + '\'' +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_BookSummary.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_BookSummary.java
@@ -21,4 +21,26 @@ public class _BookSummary {
   public Double high;
   public Double estimated_delivery_price;
   public Long creation_timestamp;
+
+  @Override
+  public String toString() {
+    return "_BookSummary{" +
+            "instrument_name='" + instrument_name + '\'' +
+            ", base_currency='" + base_currency + '\'' +
+            ", quote_currency='" + quote_currency + '\'' +
+            ", ask_price=" + ask_price +
+            ", bid_price=" + bid_price +
+            ", mid_price=" + mid_price +
+            ", mark_price=" + mark_price +
+            ", volume=" + volume +
+            ", volume_usd=" + volume_usd +
+            ", price_change=" + price_change +
+            ", open_interest=" + open_interest +
+            ", low=" + low +
+            ", last=" + last +
+            ", high=" + high +
+            ", estimated_delivery_price=" + estimated_delivery_price +
+            ", creation_timestamp=" + creation_timestamp +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Currency.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Currency.java
@@ -14,4 +14,18 @@ public class _Currency {
   public Double min_withdrawal_fee;
   public Double withdrawal_fee;
   public List<_WithdrawPriority> withdrawal_priorities;
+
+  @Override
+  public String toString() {
+    return "_Currency{" +
+            "coin_type='" + coin_type + '\'' +
+            ", currency='" + currency + '\'' +
+            ", currency_long='" + currency_long + '\'' +
+            ", fee_precision=" + fee_precision +
+            ", min_confirmations=" + min_confirmations +
+            ", min_withdrawal_fee=" + min_withdrawal_fee +
+            ", withdrawal_fee=" + withdrawal_fee +
+            ", withdrawal_priorities=" + withdrawal_priorities +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Deposit.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Deposit.java
@@ -12,4 +12,17 @@ public class _Deposit {
   public String state;
   public String transaction_id;
   public long updated_timestamp;
+
+  @Override
+  public String toString() {
+    return "_Deposit{" +
+            "address='" + address + '\'' +
+            ", amount=" + amount +
+            ", currency='" + currency + '\'' +
+            ", received_timestamp=" + received_timestamp +
+            ", state='" + state + '\'' +
+            ", transaction_id='" + transaction_id + '\'' +
+            ", updated_timestamp=" + updated_timestamp +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Error.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Error.java
@@ -7,4 +7,12 @@ public final class _Error {
 
   public int code;
   public String message;
+
+  @Override
+  public String toString() {
+    return "_Error{" +
+            "code=" + code +
+            ", message='" + message + '\'' +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Fee.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Fee.java
@@ -10,4 +10,15 @@ public class _Fee {
   public String instrument_type;
   public double maker_fee;
   public double taker_fee;
+
+  @Override
+  public String toString() {
+    return "_Fee{" +
+            "currency='" + currency + '\'' +
+            ", fee_type='" + fee_type + '\'' +
+            ", instrument_type='" + instrument_type + '\'' +
+            ", maker_fee=" + maker_fee +
+            ", taker_fee=" + taker_fee +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Greek.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Greek.java
@@ -6,4 +6,15 @@ public class _Greek {
   public double rho;
   public double theta;
   public double vega;
+
+  @Override
+  public String toString() {
+    return "_Greek{" +
+            "delta=" + delta +
+            ", gamma=" + gamma +
+            ", rho=" + rho +
+            ", theta=" + theta +
+            ", vega=" + vega +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Instrument.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Instrument.java
@@ -22,4 +22,27 @@ public class _Instrument {
   public double strike;
   public double taker_commission;
   public double tick_size;
+
+  @Override
+  public String toString() {
+    return "_Instrument{" +
+            "base_currency='" + base_currency + '\'' +
+            ", block_trade_commission=" + block_trade_commission +
+            ", contract_size=" + contract_size +
+            ", creation_timestamp=" + creation_timestamp +
+            ", expiration_timestamp=" + expiration_timestamp +
+            ", instrument_name='" + instrument_name + '\'' +
+            ", is_active=" + is_active +
+            ", kind='" + kind + '\'' +
+            ", leverage=" + leverage +
+            ", maker_commission=" + maker_commission +
+            ", min_trade_amount=" + min_trade_amount +
+            ", option_type='" + option_type + '\'' +
+            ", quote_currency='" + quote_currency + '\'' +
+            ", settlement_period='" + settlement_period + '\'' +
+            ", strike=" + strike +
+            ", taker_commission=" + taker_commission +
+            ", tick_size=" + tick_size +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Leverage.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Leverage.java
@@ -6,4 +6,11 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class _Leverage {
 
   public double leverage;
+
+  @Override
+  public String toString() {
+    return "_Leverage{" +
+            "leverage=" + leverage +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Limit.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Limit.java
@@ -7,4 +7,12 @@ public class _Limit {
 
   public int rate;
   public int burst;
+
+  @Override
+  public String toString() {
+    return "_Limit{" +
+            "rate=" + rate +
+            ", burst=" + burst +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Limits.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Limits.java
@@ -10,4 +10,15 @@ public class _Limits {
   public _Limit futures;
   public _Limit options;
   public _Limit perpetuals;
+
+  @Override
+  public String toString() {
+    return "_Limits{" +
+            "non_matching_engine=" + non_matching_engine +
+            ", matching_engine=" + matching_engine +
+            ", futures=" + futures +
+            ", options=" + options +
+            ", perpetuals=" + perpetuals +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Order.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Order.java
@@ -39,4 +39,42 @@ public class _Order {
   public double implv;
   public String trigger;
 
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "order_state='" + order_state + '\'' +
+            ", max_show=" + max_show +
+            ", api=" + api +
+            ", amount=" + amount +
+            ", web=" + web +
+            ", instrument_name='" + instrument_name + '\'' +
+            ", advanced='" + advanced + '\'' +
+            ", triggered=" + triggered +
+            ", block_trade=" + block_trade +
+            ", original_order_type='" + original_order_type + '\'' +
+            ", price=" + price +
+            ", time_in_force='" + time_in_force + '\'' +
+            ", auto_replaced=" + auto_replaced +
+            ", stop_order_id='" + stop_order_id + '\'' +
+            ", last_update_timestamp=" + last_update_timestamp +
+            ", post_only=" + post_only +
+            ", replaced=" + replaced +
+            ", filled_amount=" + filled_amount +
+            ", average_price=" + average_price +
+            ", order_id='" + order_id + '\'' +
+            ", reduce_only=" + reduce_only +
+            ", commission=" + commission +
+            ", app_name='" + app_name + '\'' +
+            ", stop_price=" + stop_price +
+            ", label='" + label + '\'' +
+            ", creation_timestamp=" + creation_timestamp +
+            ", direction='" + direction + '\'' +
+            ", is_liquidation=" + is_liquidation +
+            ", order_type='" + order_type + '\'' +
+            ", usd=" + usd +
+            ", profit_loss=" + profit_loss +
+            ", implv=" + implv +
+            ", trigger='" + trigger + '\'' +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_OrderBook.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_OrderBook.java
@@ -34,5 +34,38 @@ public class _OrderBook {
   public long timestamp;
   public double underlying_index;
   public double underlying_price;
+
+  @Override
+  public String toString() {
+    return "_OrderBook{" +
+            "ask_iv=" + ask_iv +
+            ", asks=" + asks +
+            ", best_ask_amount=" + best_ask_amount +
+            ", best_ask_price=" + best_ask_price +
+            ", best_bid_amount=" + best_bid_amount +
+            ", best_bid_price=" + best_bid_price +
+            ", bid_iv=" + bid_iv +
+            ", bids=" + bids +
+            ", current_funding=" + current_funding +
+            ", delivery_price=" + delivery_price +
+            ", funding_8h=" + funding_8h +
+            ", greeks=" + greeks +
+            ", index_price=" + index_price +
+            ", instrument_name='" + instrument_name + '\'' +
+            ", interest_rate=" + interest_rate +
+            ", last_price=" + last_price +
+            ", mark_iv=" + mark_iv +
+            ", mark_price=" + mark_price +
+            ", max_price=" + max_price +
+            ", min_price=" + min_price +
+            ", open_interest=" + open_interest +
+            ", settlement_price=" + settlement_price +
+            ", state='" + state + '\'' +
+            ", stats=" + stats +
+            ", timestamp=" + timestamp +
+            ", underlying_index=" + underlying_index +
+            ", underlying_price=" + underlying_price +
+            '}';
+  }
 }
 

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_PlaceOrderResponse.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_PlaceOrderResponse.java
@@ -5,4 +5,12 @@ import java.util.List;
 public class _PlaceOrderResponse {
   public _Order order;
   public List<_Trade> trades;
+
+  @Override
+  public String toString() {
+    return "_PlaceOrderResponse{" +
+            "order=" + order +
+            ", trades=" + trades +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Position.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Position.java
@@ -29,4 +29,34 @@ public class _Position {
   public double theta;
   public double total_profit_loss;
   public double vega;
+
+  @Override
+  public String toString() {
+    return "_Position{" +
+            "average_price=" + average_price +
+            ", average_price_usd=" + average_price_usd +
+            ", delta=" + delta +
+            ", direction='" + direction + '\'' +
+            ", estimated_liquidation_price=" + estimated_liquidation_price +
+            ", floating_profit_loss=" + floating_profit_loss +
+            ", floating_profit_loss_usd=" + floating_profit_loss_usd +
+            ", gamma=" + gamma +
+            ", index_price=" + index_price +
+            ", initial_margin=" + initial_margin +
+            ", instrument_name='" + instrument_name + '\'' +
+            ", kind='" + kind + '\'' +
+            ", leverage=" + leverage +
+            ", maintenance_margin=" + maintenance_margin +
+            ", mark_price=" + mark_price +
+            ", open_orders_margin=" + open_orders_margin +
+            ", realized_funding=" + realized_funding +
+            ", realized_profit_loss=" + realized_profit_loss +
+            ", settlement_price=" + settlement_price +
+            ", size=" + size +
+            ", size_currency='" + size_currency + '\'' +
+            ", theta=" + theta +
+            ", total_profit_loss=" + total_profit_loss +
+            ", vega=" + vega +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Stats.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Stats.java
@@ -5,4 +5,14 @@ public class _Stats {
   public double low;
   public double price_change;
   public double volume;
+
+  @Override
+  public String toString() {
+    return "_Stats{" +
+            "high=" + high +
+            ", low=" + low +
+            ", price_change=" + price_change +
+            ", volume=" + volume +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Ticker.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Ticker.java
@@ -24,4 +24,29 @@ public class _Ticker {
   public String state;
   public _Stats stats;
   public long timestamp;
+
+  @Override
+  public String toString() {
+    return "_Ticker{" +
+            "best_ask_amount=" + best_ask_amount +
+            ", best_ask_price=" + best_ask_price +
+            ", best_bid_amount=" + best_bid_amount +
+            ", best_bid_price=" + best_bid_price +
+            ", current_funding=" + current_funding +
+            ", funding_8h=" + funding_8h +
+            ", greeks=" + greeks +
+            ", index_price=" + index_price +
+            ", instrument_name='" + instrument_name + '\'' +
+            ", interest_rate=" + interest_rate +
+            ", last_price=" + last_price +
+            ", mark_price=" + mark_price +
+            ", max_price=" + max_price +
+            ", min_price=" + min_price +
+            ", open_interest=" + open_interest +
+            ", settlement_price=" + settlement_price +
+            ", state='" + state + '\'' +
+            ", stats=" + stats +
+            ", timestamp=" + timestamp +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Trade.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_Trade.java
@@ -29,4 +29,32 @@ public class _Trade {
   public String advanced;
   public boolean mmp;
 
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "amount=" + amount +
+            ", block_trade_id='" + block_trade_id + '\'' +
+            ", direction='" + direction + '\'' +
+            ", fee=" + fee +
+            ", fee_currency='" + fee_currency + '\'' +
+            ", index_price=" + index_price +
+            ", instrument_name='" + instrument_name + '\'' +
+            ", iv=" + iv +
+            ", label='" + label + '\'' +
+            ", liquidation='" + liquidation + '\'' +
+            ", liquidity='" + liquidity + '\'' +
+            ", mark_price=" + mark_price +
+            ", matching_id='" + matching_id + '\'' +
+            ", order_id='" + order_id + '\'' +
+            ", order_type='" + order_type + '\'' +
+            ", post_only='" + post_only + '\'' +
+            ", price=" + price +
+            ", profit_loss=" + profit_loss +
+            ", reduce_only=" + reduce_only +
+            ", stop_price=" + stop_price +
+            ", trigger='" + trigger + '\'' +
+            ", advanced='" + advanced + '\'' +
+            ", mmp=" + mmp +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_WithdrawPriority.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/common/_WithdrawPriority.java
@@ -7,4 +7,12 @@ public class _WithdrawPriority {
 
   public Double value;
   public String name;
+
+  @Override
+  public String toString() {
+    return "_WithdrawPriority{" +
+            "value=" + value +
+            ", name='" + name + '\'' +
+            '}';
+  }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/websocket/market/BookChannel.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/websocket/market/BookChannel.java
@@ -48,5 +48,16 @@ public final class BookChannel extends MarketWebSocketChannel<BookChannel.Id, Bo
     public long change_id;
     public List<_OrderBookLevel> bids;
     public List<_OrderBookLevel> asks;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "timestamp=" + timestamp +
+              ", instrument_name='" + instrument_name + '\'' +
+              ", change_id=" + change_id +
+              ", bids=" + bids +
+              ", asks=" + asks +
+              '}';
+    }
   }
 }

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/websocket/market/TradesChannel.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/websocket/market/TradesChannel.java
@@ -56,5 +56,24 @@ public final class TradesChannel
     public long timestamp;
     public String trade_id;
     public long trade_seq;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "amount=" + amount +
+              ", block_trade_id='" + block_trade_id + '\'' +
+              ", direction='" + direction + '\'' +
+              ", index_price=" + index_price +
+              ", instrument_name='" + instrument_name + '\'' +
+              ", iv=" + iv +
+              ", liquidation='" + liquidation + '\'' +
+              ", mark_price=" + mark_price +
+              ", price=" + price +
+              ", tick_direction=" + tick_direction +
+              ", timestamp=" + timestamp +
+              ", trade_id='" + trade_id + '\'' +
+              ", trade_seq=" + trade_seq +
+              '}';
+    }
   }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_AccountInformation.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_AccountInformation.java
@@ -1,10 +1,11 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 import java.util.List;
 
 @NotThreadSafe
-public class _AccountInformation {
+public class _AccountInformation implements Serializable {
 
   public Boolean backstopProvider;
   public Double collateral;
@@ -21,4 +22,41 @@ public class _AccountInformation {
   public Double totalPositionSize;
   public String username;
   public List<_Position> positions;
+
+  @Override
+  public String toString() {
+    return "_AccountInformation{"
+        + "backstopProvider="
+        + backstopProvider
+        + ", collateral="
+        + collateral
+        + ", freeCollateral="
+        + freeCollateral
+        + ", initialMarginRequirement="
+        + initialMarginRequirement
+        + ", leverage="
+        + leverage
+        + ", liquidating="
+        + liquidating
+        + ", maintenanceMarginRequirement="
+        + maintenanceMarginRequirement
+        + ", makerFee="
+        + makerFee
+        + ", marginFraction="
+        + marginFraction
+        + ", openMarginFraction="
+        + openMarginFraction
+        + ", takerFee="
+        + takerFee
+        + ", totalAccountValue="
+        + totalAccountValue
+        + ", totalPositionSize="
+        + totalPositionSize
+        + ", username='"
+        + username
+        + '\''
+        + ", positions="
+        + positions
+        + '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Candle.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Candle.java
@@ -1,8 +1,5 @@
 package io.contek.invoker.ftx.api.common;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
-@NotThreadSafe
 public class _Candle {
 
   public Double close;
@@ -11,4 +8,23 @@ public class _Candle {
   public Double open;
   public String startTime;
   public Double volume;
+
+  @Override
+  public String toString() {
+    return "_Candle{"
+        + "close="
+        + close
+        + ", high="
+        + high
+        + ", low="
+        + low
+        + ", open="
+        + open
+        + ", startTime='"
+        + startTime
+        + '\''
+        + ", volume="
+        + volume
+        + '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Leverage.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Leverage.java
@@ -1,9 +1,17 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 
 @NotThreadSafe
-public class _Leverage {
+public class _Leverage implements Serializable {
 
   public Double leverage;
+
+  @Override
+  public String toString() {
+    return "_Leverage{" +
+            "leverage=" + leverage +
+            '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Market.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Market.java
@@ -1,9 +1,10 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 
 @NotThreadSafe
-public class _Market {
+public class _Market implements Serializable {
 
   public String name;
   public String baseCurrency;
@@ -18,4 +19,41 @@ public class _Market {
   public Double priceIncrement;
   public Double sizeIncrement;
   public Boolean restricted;
+
+  @Override
+  public String toString() {
+    return "_Market{"
+        + "name='"
+        + name
+        + '\''
+        + ", baseCurrency='"
+        + baseCurrency
+        + '\''
+        + ", quoteCurrency='"
+        + quoteCurrency
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", underlying='"
+        + underlying
+        + '\''
+        + ", enabled="
+        + enabled
+        + ", ask="
+        + ask
+        + ", bid="
+        + bid
+        + ", last="
+        + last
+        + ", postOnly="
+        + postOnly
+        + ", priceIncrement="
+        + priceIncrement
+        + ", sizeIncrement="
+        + sizeIncrement
+        + ", restricted="
+        + restricted
+        + '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Order.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Order.java
@@ -1,9 +1,10 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 
 @NotThreadSafe
-public class _Order {
+public class _Order implements Serializable {
 
   public String createdAt;
   public Double filledSize;
@@ -21,4 +22,49 @@ public class _Order {
   public Boolean ioc;
   public Boolean postOnly;
   public String clientId;
+
+  @Override
+  public String toString() {
+    return "_Order{"
+        + "createdAt='"
+        + createdAt
+        + '\''
+        + ", filledSize="
+        + filledSize
+        + ", future='"
+        + future
+        + '\''
+        + ", id="
+        + id
+        + ", market='"
+        + market
+        + '\''
+        + ", price="
+        + price
+        + ", avgFillPrice="
+        + avgFillPrice
+        + ", remainingSize="
+        + remainingSize
+        + ", side='"
+        + side
+        + '\''
+        + ", size="
+        + size
+        + ", status='"
+        + status
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", reduceOnly="
+        + reduceOnly
+        + ", ioc="
+        + ioc
+        + ", postOnly="
+        + postOnly
+        + ", clientId='"
+        + clientId
+        + '\''
+        + '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_OrderBook.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_OrderBook.java
@@ -1,11 +1,20 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 import java.util.List;
 
 @NotThreadSafe
-public class _OrderBook {
+public class _OrderBook implements Serializable {
 
   public List<_OrderBookLevel> asks;
   public List<_OrderBookLevel> bids;
+
+  @Override
+  public String toString() {
+    return "_OrderBook{" +
+            "asks=" + asks +
+            ", bids=" + bids +
+            '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_OrderBookLevel.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_OrderBookLevel.java
@@ -1,7 +1,8 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 import java.util.ArrayList;
 
 @NotThreadSafe
-public class _OrderBookLevel extends ArrayList<Double> {}
+public class _OrderBookLevel extends ArrayList<Double> implements Serializable {}

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Position.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Position.java
@@ -1,9 +1,10 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 
 @NotThreadSafe
-public class _Position {
+public class _Position implements Serializable {
 
   public Double cost;
   public Double entryPrice;
@@ -23,4 +24,48 @@ public class _Position {
   public Double recentAverageOpenPrice;
   public Double recentBreakEvenPrice;
   public Double recentPnl;
+
+  @Override
+  public String toString() {
+    return "_Position{"
+        + "cost="
+        + cost
+        + ", entryPrice="
+        + entryPrice
+        + ", estimatedLiquidationPrice="
+        + estimatedLiquidationPrice
+        + ", future='"
+        + future
+        + '\''
+        + ", initialMarginRequirement="
+        + initialMarginRequirement
+        + ", longOrderSize="
+        + longOrderSize
+        + ", maintenanceMarginRequirement="
+        + maintenanceMarginRequirement
+        + ", netSize="
+        + netSize
+        + ", openSize="
+        + openSize
+        + ", realizedPnl="
+        + realizedPnl
+        + ", shortOrderSize="
+        + shortOrderSize
+        + ", side='"
+        + side
+        + '\''
+        + ", size="
+        + size
+        + ", unrealizedPnl="
+        + unrealizedPnl
+        + ", collateralUsed="
+        + collateralUsed
+        + ", recentAverageOpenPrice="
+        + recentAverageOpenPrice
+        + ", recentBreakEvenPrice="
+        + recentBreakEvenPrice
+        + ", recentPnl="
+        + recentPnl
+        + '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Ticker.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Ticker.java
@@ -1,9 +1,10 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 
 @NotThreadSafe
-public class _Ticker {
+public class _Ticker implements Serializable {
 
   public Double bid;
   public Double ask;
@@ -11,4 +12,22 @@ public class _Ticker {
   public Double bidSize;
   public Double last;
   public Double time;
+
+  @Override
+  public String toString() {
+    return "_Ticker{"
+        + "bid="
+        + bid
+        + ", ask="
+        + ask
+        + ", askSize="
+        + askSize
+        + ", bidSize="
+        + bidSize
+        + ", last="
+        + last
+        + ", time="
+        + time
+        + '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Trade.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_Trade.java
@@ -1,14 +1,35 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 
 @NotThreadSafe
-public class _Trade {
+public class _Trade implements Serializable {
 
-  public long id;
-  public boolean liquidation;
-  public double price;
+  public Long id;
+  public Boolean liquidation;
+  public Double price;
   public String side;
-  public double size;
+  public Double size;
   public String time;
+
+  @Override
+  public String toString() {
+    return "_Trade{"
+        + "id="
+        + id
+        + ", liquidation="
+        + liquidation
+        + ", price="
+        + price
+        + ", side='"
+        + side
+        + '\''
+        + ", size="
+        + size
+        + ", time='"
+        + time
+        + '\''
+        + '}';
+  }
 }

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_WalletBalance.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/common/_WalletBalance.java
@@ -1,11 +1,21 @@
 package io.contek.invoker.ftx.api.common;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
 
 @NotThreadSafe
-public class _WalletBalance {
+public class _WalletBalance implements Serializable {
 
   public String coin;
-  public double free;
-  public double total;
+  public Double free;
+  public Double total;
+
+  @Override
+  public String toString() {
+    return "_WalletBalance{" +
+            "coin='" + coin + '\'' +
+            ", free=" + free +
+            ", total=" + total +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_AccountInfo.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_AccountInfo.java
@@ -19,4 +19,24 @@ public class _AccountInfo {
   public double adjust_factor;
   public double margin_static;
   public String contract_code;
+
+  @Override
+  public String toString() {
+    return "_AccountInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", margin_balance=" + margin_balance +
+            ", margin_position=" + margin_position +
+            ", margin_frozen=" + margin_frozen +
+            ", margin_available=" + margin_available +
+            ", profit_real=" + profit_real +
+            ", profit_unreal=" + profit_unreal +
+            ", risk_rate=" + risk_rate +
+            ", withdraw_available=" + withdraw_available +
+            ", liquidation_price=" + liquidation_price +
+            ", lever_rate=" + lever_rate +
+            ", adjust_factor=" + adjust_factor +
+            ", margin_static=" + margin_static +
+            ", contract_code='" + contract_code + '\'' +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_AccountPositionInfo.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_AccountPositionInfo.java
@@ -21,4 +21,25 @@ public class _AccountPositionInfo {
   public double adjust_factor;
   public double margin_static;
   public List<_PositionInfo> positions;
+
+  @Override
+  public String toString() {
+    return "_AccountPositionInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", margin_balance=" + margin_balance +
+            ", margin_position=" + margin_position +
+            ", margin_frozen=" + margin_frozen +
+            ", margin_available=" + margin_available +
+            ", profit_real=" + profit_real +
+            ", profit_unreal=" + profit_unreal +
+            ", risk_rate=" + risk_rate +
+            ", withdraw_available=" + withdraw_available +
+            ", liquidation_price=" + liquidation_price +
+            ", lever_rate=" + lever_rate +
+            ", adjust_factor=" + adjust_factor +
+            ", margin_static=" + margin_static +
+            ", positions=" + positions +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_AvailableLevelRate.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_AvailableLevelRate.java
@@ -7,4 +7,12 @@ public class _AvailableLevelRate {
 
   public String contract_code;
   public String available_level_rate;
+
+  @Override
+  public String toString() {
+    return "_AvailableLevelRate{" +
+            "contract_code='" + contract_code + '\'' +
+            ", available_level_rate='" + available_level_rate + '\'' +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_ContractInfo.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_ContractInfo.java
@@ -13,4 +13,18 @@ public class _ContractInfo {
   public String create_date;
   public int contract_status;
   public String settlement_date;
+
+  @Override
+  public String toString() {
+    return "_ContractInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", contract_size=" + contract_size +
+            ", price_tick=" + price_tick +
+            ", delivery_time='" + delivery_time + '\'' +
+            ", create_date='" + create_date + '\'' +
+            ", contract_status=" + contract_status +
+            ", settlement_date='" + settlement_date + '\'' +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Depth.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Depth.java
@@ -13,4 +13,17 @@ public class _Depth {
   public long mrid;
   public long ts;
   public long version;
+
+  @Override
+  public String toString() {
+    return "_Depth{" +
+            "asks=" + asks +
+            ", bids=" + bids +
+            ", ch='" + ch + '\'' +
+            ", id=" + id +
+            ", mrid=" + mrid +
+            ", ts=" + ts +
+            ", version=" + version +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Kline.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Kline.java
@@ -15,4 +15,20 @@ public class _Kline {
   public double vol;
   public double trade_turnover;
   public double count;
+
+  @Override
+  public String toString() {
+    return "_Kline{" +
+            "id=" + id +
+            ", mrid=" + mrid +
+            ", open=" + open +
+            ", close=" + close +
+            ", high=" + high +
+            ", low=" + low +
+            ", amount=" + amount +
+            ", vol=" + vol +
+            ", trade_turnover=" + trade_turnover +
+            ", count=" + count +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_LeverRate.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_LeverRate.java
@@ -7,4 +7,12 @@ public class _LeverRate {
 
   public String contract_code;
   public int lever_rate;
+
+  @Override
+  public String toString() {
+    return "_LeverRate{" +
+            "contract_code='" + contract_code + '\'' +
+            ", lever_rate=" + lever_rate +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_LiquidationOrder.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_LiquidationOrder.java
@@ -13,4 +13,18 @@ public class _LiquidationOrder {
   public long created_at;
   public double amount;
   public double trade_turnover;
+
+  @Override
+  public String toString() {
+    return "_LiquidationOrder{" +
+            "contract_code='" + contract_code + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", direction='" + direction + '\'' +
+            ", offset='" + offset + '\'' +
+            ", volume=" + volume +
+            ", created_at=" + created_at +
+            ", amount=" + amount +
+            ", trade_turnover=" + trade_turnover +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_MarketDetail.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_MarketDetail.java
@@ -17,4 +17,22 @@ public class _MarketDetail {
   public String amount;
   public int count;
   public String vol;
+
+  @Override
+  public String toString() {
+    return "_MarketDetail{" +
+            "id=" + id +
+            ", ts=" + ts +
+            ", ask=" + ask +
+            ", bid=" + bid +
+            ", contract_code='" + contract_code + '\'' +
+            ", open='" + open + '\'' +
+            ", close='" + close + '\'' +
+            ", low='" + low + '\'' +
+            ", high='" + high + '\'' +
+            ", amount='" + amount + '\'' +
+            ", count=" + count +
+            ", vol='" + vol + '\'' +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Order.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Order.java
@@ -18,4 +18,23 @@ public class _Order {
   public String sl_trigger_price;
   public String sl_order_price;
   public String sl_order_price_type;
+
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "contract_code='" + contract_code + '\'' +
+            ", direction='" + direction + '\'' +
+            ", offset='" + offset + '\'' +
+            ", price='" + price + '\'' +
+            ", lever_rate=" + lever_rate +
+            ", volume=" + volume +
+            ", order_price_type='" + order_price_type + '\'' +
+            ", tp_trigger_price=" + tp_trigger_price +
+            ", tp_order_price=" + tp_order_price +
+            ", tp_order_price_type='" + tp_order_price_type + '\'' +
+            ", sl_trigger_price='" + sl_trigger_price + '\'' +
+            ", sl_order_price='" + sl_order_price + '\'' +
+            ", sl_order_price_type='" + sl_order_price_type + '\'' +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_OrderIdentifier.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_OrderIdentifier.java
@@ -8,4 +8,13 @@ public class _OrderIdentifier {
   public long order_id;
   public String order_id_str;
   public Long client_order_id;
+
+  @Override
+  public String toString() {
+    return "_OrderIdentifier{" +
+            "order_id=" + order_id +
+            ", order_id_str='" + order_id_str + '\'' +
+            ", client_order_id=" + client_order_id +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_OrderInfo.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_OrderInfo.java
@@ -31,4 +31,36 @@ public class _OrderInfo {
   public long canceled_at;
   public double real_profit;
   public int is_tpsl;
+
+  @Override
+  public String toString() {
+    return "_OrderInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", volume=" + volume +
+            ", price=" + price +
+            ", order_price_type='" + order_price_type + '\'' +
+            ", order_type=" + order_type +
+            ", direction='" + direction + '\'' +
+            ", offset='" + offset + '\'' +
+            ", lever_rate=" + lever_rate +
+            ", order_id=" + order_id +
+            ", client_order_id=" + client_order_id +
+            ", created_at=" + created_at +
+            ", trade_volume=" + trade_volume +
+            ", trade_turnover=" + trade_turnover +
+            ", fee=" + fee +
+            ", trade_avg_price=" + trade_avg_price +
+            ", margin_frozen=" + margin_frozen +
+            ", profit=" + profit +
+            ", status=" + status +
+            ", order_source='" + order_source + '\'' +
+            ", order_id_str='" + order_id_str + '\'' +
+            ", fee_asset='" + fee_asset + '\'' +
+            ", liquidation_type='" + liquidation_type + '\'' +
+            ", canceled_at=" + canceled_at +
+            ", real_profit=" + real_profit +
+            ", is_tpsl=" + is_tpsl +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_PositionInfo.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_PositionInfo.java
@@ -19,4 +19,24 @@ public class _PositionInfo {
   public String direction;
   public double profit;
   public Double last_price;
+
+  @Override
+  public String toString() {
+    return "_PositionInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", volume=" + volume +
+            ", available=" + available +
+            ", frozen=" + frozen +
+            ", cost_open=" + cost_open +
+            ", cost_hold=" + cost_hold +
+            ", profit_unreal=" + profit_unreal +
+            ", profit_rate=" + profit_rate +
+            ", lever_rate=" + lever_rate +
+            ", position_margin=" + position_margin +
+            ", direction='" + direction + '\'' +
+            ", profit=" + profit +
+            ", last_price=" + last_price +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Trade.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_Trade.java
@@ -12,4 +12,17 @@ public class _Trade {
   public long ts;
   public double quantity;
   public double trade_turnover;
+
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "amount=" + amount +
+            ", direction='" + direction + '\'' +
+            ", id=" + id +
+            ", price=" + price +
+            ", ts=" + ts +
+            ", quantity=" + quantity +
+            ", trade_turnover=" + trade_turnover +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_TradeDetail.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/common/_TradeDetail.java
@@ -9,4 +9,13 @@ public class _TradeDetail {
   public List<_Trade> data;
   public long id;
   public long ts;
+
+  @Override
+  public String toString() {
+    return "_TradeDetail{" +
+            "data=" + data +
+            ", id=" + id +
+            ", ts=" + ts +
+            '}';
+  }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/rest/user/PostSwapCancel.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/rest/user/PostSwapCancel.java
@@ -81,6 +81,14 @@ public final class PostSwapCancel extends UserRestRequest<PostSwapCancel.Respons
 
     public List<Error> errors;
     public String successes;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "errors=" + errors +
+              ", successes='" + successes + '\'' +
+              '}';
+    }
   }
 
   @NotThreadSafe

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/rest/user/PostSwapOpenorders.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/rest/user/PostSwapOpenorders.java
@@ -102,5 +102,12 @@ public final class PostSwapOpenorders extends UserRestRequest<PostSwapOpenorders
   public static final class Data extends PaginatedData {
 
     public List<_OrderInfo> orders;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "orders=" + orders +
+              '}';
+    }
   }
 }

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/websocket/market/IncrementalDepthChannel.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/websocket/market/IncrementalDepthChannel.java
@@ -52,6 +52,20 @@ public final class IncrementalDepthChannel
   public static final class Tick extends _Depth {
 
     public String event;
+
+    @Override
+    public String toString() {
+      return "Tick{" +
+              "asks=" + asks +
+              ", bids=" + bids +
+              ", ch='" + ch + '\'' +
+              ", id=" + id +
+              ", mrid=" + mrid +
+              ", ts=" + ts +
+              ", version=" + version +
+              ", event='" + event + '\'' +
+              '}';
+    }
   }
 
   @NotThreadSafe

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_AvailableLevelRate.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_AvailableLevelRate.java
@@ -8,4 +8,13 @@ public class _AvailableLevelRate {
   public String contract_code;
   public String available_level_rate;
   public String margin_mode;
+
+  @Override
+  public String toString() {
+    return "_AvailableLevelRate{" +
+            "contract_code='" + contract_code + '\'' +
+            ", available_level_rate='" + available_level_rate + '\'' +
+            ", margin_mode='" + margin_mode + '\'' +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_ContractInfo.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_ContractInfo.java
@@ -14,4 +14,19 @@ public class _ContractInfo {
   public int contract_status;
   public String settlement_date;
   public String support_margin_mode;
+
+  @Override
+  public String toString() {
+    return "_ContractInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", contract_size=" + contract_size +
+            ", price_tick=" + price_tick +
+            ", delivery_time='" + delivery_time + '\'' +
+            ", create_date='" + create_date + '\'' +
+            ", contract_status=" + contract_status +
+            ", settlement_date='" + settlement_date + '\'' +
+            ", support_margin_mode='" + support_margin_mode + '\'' +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_CrossAccountContractDetail.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_CrossAccountContractDetail.java
@@ -14,4 +14,19 @@ public class _CrossAccountContractDetail {
   public Double liquidation_price;
   public int lever_rate;
   public double adjust_factor;
+
+  @Override
+  public String toString() {
+    return "_CrossAccountContractDetail{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", margin_position=" + margin_position +
+            ", margin_frozen=" + margin_frozen +
+            ", margin_available=" + margin_available +
+            ", profit_unreal=" + profit_unreal +
+            ", liquidation_price=" + liquidation_price +
+            ", lever_rate=" + lever_rate +
+            ", adjust_factor=" + adjust_factor +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_CrossAccountInfo.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_CrossAccountInfo.java
@@ -18,4 +18,22 @@ public class _CrossAccountInfo {
   public double withdraw_available;
   public Double risk_rate;
   public List<_CrossAccountContractDetail> contract_detail;
+
+  @Override
+  public String toString() {
+    return "_CrossAccountInfo{" +
+            "margin_mode='" + margin_mode + '\'' +
+            ", margin_account='" + margin_account + '\'' +
+            ", margin_asset='" + margin_asset + '\'' +
+            ", margin_balance=" + margin_balance +
+            ", margin_static=" + margin_static +
+            ", margin_position=" + margin_position +
+            ", margin_frozen=" + margin_frozen +
+            ", profit_real=" + profit_real +
+            ", profit_unreal=" + profit_unreal +
+            ", withdraw_available=" + withdraw_available +
+            ", risk_rate=" + risk_rate +
+            ", contract_detail=" + contract_detail +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_CrossAccountPositionInfo.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_CrossAccountPositionInfo.java
@@ -19,4 +19,23 @@ public class _CrossAccountPositionInfo {
   public double risk_rate;
   public List<_PositionInfo> positions;
   public List<_CrossAccountContractDetail> contract_detail;
+
+  @Override
+  public String toString() {
+    return "_CrossAccountPositionInfo{" +
+            "margin_mode='" + margin_mode + '\'' +
+            ", margin_account='" + margin_account + '\'' +
+            ", margin_asset='" + margin_asset + '\'' +
+            ", margin_balance=" + margin_balance +
+            ", margin_static=" + margin_static +
+            ", margin_position=" + margin_position +
+            ", margin_frozen=" + margin_frozen +
+            ", profit_real=" + profit_real +
+            ", profit_unreal=" + profit_unreal +
+            ", withdraw_available=" + withdraw_available +
+            ", risk_rate=" + risk_rate +
+            ", positions=" + positions +
+            ", contract_detail=" + contract_detail +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Depth.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Depth.java
@@ -13,4 +13,17 @@ public class _Depth {
   public long mrid;
   public long ts;
   public long version;
+
+  @Override
+  public String toString() {
+    return "_Depth{" +
+            "asks=" + asks +
+            ", bids=" + bids +
+            ", ch='" + ch + '\'' +
+            ", id=" + id +
+            ", mrid=" + mrid +
+            ", ts=" + ts +
+            ", version=" + version +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Kline.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Kline.java
@@ -15,4 +15,20 @@ public class _Kline {
   public double vol;
   public double trade_turnover;
   public double count;
+
+  @Override
+  public String toString() {
+    return "_Kline{" +
+            "id=" + id +
+            ", mrid=" + mrid +
+            ", open=" + open +
+            ", close=" + close +
+            ", high=" + high +
+            ", low=" + low +
+            ", amount=" + amount +
+            ", vol=" + vol +
+            ", trade_turnover=" + trade_turnover +
+            ", count=" + count +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_LeverRate.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_LeverRate.java
@@ -8,4 +8,13 @@ public class _LeverRate {
   public String contract_code;
   public int lever_rate;
   public String margin_mode;
+
+  @Override
+  public String toString() {
+    return "_LeverRate{" +
+            "contract_code='" + contract_code + '\'' +
+            ", lever_rate=" + lever_rate +
+            ", margin_mode='" + margin_mode + '\'' +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_LiquidationOrder.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_LiquidationOrder.java
@@ -13,4 +13,18 @@ public class _LiquidationOrder {
   public long created_at;
   public double amount;
   public double trade_turnover;
+
+  @Override
+  public String toString() {
+    return "_LiquidationOrder{" +
+            "contract_code='" + contract_code + '\'' +
+            ", symbol='" + symbol + '\'' +
+            ", direction='" + direction + '\'' +
+            ", offset='" + offset + '\'' +
+            ", volume=" + volume +
+            ", created_at=" + created_at +
+            ", amount=" + amount +
+            ", trade_turnover=" + trade_turnover +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_MarketDetail.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_MarketDetail.java
@@ -18,4 +18,23 @@ public class _MarketDetail {
   public int count;
   public String vol;
   public String trade_turnover;
+
+  @Override
+  public String toString() {
+    return "_MarketDetail{" +
+            "id=" + id +
+            ", ts=" + ts +
+            ", ask=" + ask +
+            ", bid=" + bid +
+            ", contract_code='" + contract_code + '\'' +
+            ", open='" + open + '\'' +
+            ", close='" + close + '\'' +
+            ", low='" + low + '\'' +
+            ", high='" + high + '\'' +
+            ", amount='" + amount + '\'' +
+            ", count=" + count +
+            ", vol='" + vol + '\'' +
+            ", trade_turnover='" + trade_turnover + '\'' +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Order.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Order.java
@@ -18,4 +18,23 @@ public class _Order {
   public String sl_trigger_price;
   public String sl_order_price;
   public String sl_order_price_type;
+
+  @Override
+  public String toString() {
+    return "_Order{" +
+            "contract_code='" + contract_code + '\'' +
+            ", direction='" + direction + '\'' +
+            ", offset='" + offset + '\'' +
+            ", price='" + price + '\'' +
+            ", lever_rate=" + lever_rate +
+            ", volume=" + volume +
+            ", order_price_type='" + order_price_type + '\'' +
+            ", tp_trigger_price=" + tp_trigger_price +
+            ", tp_order_price=" + tp_order_price +
+            ", tp_order_price_type='" + tp_order_price_type + '\'' +
+            ", sl_trigger_price='" + sl_trigger_price + '\'' +
+            ", sl_order_price='" + sl_order_price + '\'' +
+            ", sl_order_price_type='" + sl_order_price_type + '\'' +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_OrderIdentifier.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_OrderIdentifier.java
@@ -8,4 +8,13 @@ public class _OrderIdentifier {
   public long order_id;
   public String order_id_str;
   public Long client_order_id;
+
+  @Override
+  public String toString() {
+    return "_OrderIdentifier{" +
+            "order_id=" + order_id +
+            ", order_id_str='" + order_id_str + '\'' +
+            ", client_order_id=" + client_order_id +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_OrderInfo.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_OrderInfo.java
@@ -34,4 +34,39 @@ public class _OrderInfo {
   public String margin_account;
   public int is_tpsl;
   public double real_profit;
+
+  @Override
+  public String toString() {
+    return "_OrderInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", volume=" + volume +
+            ", price=" + price +
+            ", order_price_type='" + order_price_type + '\'' +
+            ", order_type=" + order_type +
+            ", direction='" + direction + '\'' +
+            ", offset='" + offset + '\'' +
+            ", lever_rate=" + lever_rate +
+            ", order_id=" + order_id +
+            ", client_order_id=" + client_order_id +
+            ", created_at=" + created_at +
+            ", trade_volume=" + trade_volume +
+            ", trade_turnover=" + trade_turnover +
+            ", fee=" + fee +
+            ", trade_avg_price=" + trade_avg_price +
+            ", margin_frozen=" + margin_frozen +
+            ", profit=" + profit +
+            ", status=" + status +
+            ", order_source='" + order_source + '\'' +
+            ", order_id_str='" + order_id_str + '\'' +
+            ", fee_asset='" + fee_asset + '\'' +
+            ", liquidation_type='" + liquidation_type + '\'' +
+            ", canceled_at=" + canceled_at +
+            ", margin_asset='" + margin_asset + '\'' +
+            ", margin_mode='" + margin_mode + '\'' +
+            ", margin_account='" + margin_account + '\'' +
+            ", is_tpsl=" + is_tpsl +
+            ", real_profit=" + real_profit +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_PositionInfo.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_PositionInfo.java
@@ -22,4 +22,27 @@ public class _PositionInfo {
   public String margin_asset;
   public String margin_mode;
   public String margin_account;
+
+  @Override
+  public String toString() {
+    return "_PositionInfo{" +
+            "symbol='" + symbol + '\'' +
+            ", contract_code='" + contract_code + '\'' +
+            ", volume=" + volume +
+            ", available=" + available +
+            ", frozen=" + frozen +
+            ", cost_open=" + cost_open +
+            ", cost_hold=" + cost_hold +
+            ", profit_unreal=" + profit_unreal +
+            ", profit_rate=" + profit_rate +
+            ", lever_rate=" + lever_rate +
+            ", position_margin=" + position_margin +
+            ", direction='" + direction + '\'' +
+            ", profit=" + profit +
+            ", last_price=" + last_price +
+            ", margin_asset='" + margin_asset + '\'' +
+            ", margin_mode='" + margin_mode + '\'' +
+            ", margin_account='" + margin_account + '\'' +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Trade.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_Trade.java
@@ -12,4 +12,17 @@ public class _Trade {
   public long ts;
   public double quantity;
   public double trade_turnover;
+
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "amount=" + amount +
+            ", direction='" + direction + '\'' +
+            ", id=" + id +
+            ", price=" + price +
+            ", ts=" + ts +
+            ", quantity=" + quantity +
+            ", trade_turnover=" + trade_turnover +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_TradeDetail.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/common/_TradeDetail.java
@@ -9,4 +9,13 @@ public class _TradeDetail {
   public List<_Trade> data;
   public long id;
   public long ts;
+
+  @Override
+  public String toString() {
+    return "_TradeDetail{" +
+            "data=" + data +
+            ", id=" + id +
+            ", ts=" + ts +
+            '}';
+  }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/rest/user/PostSwapCrossCancel.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/rest/user/PostSwapCrossCancel.java
@@ -81,6 +81,14 @@ public final class PostSwapCrossCancel extends UserRestRequest<PostSwapCrossCanc
 
     public List<Error> errors;
     public String successes;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "errors=" + errors +
+              ", successes='" + successes + '\'' +
+              '}';
+    }
   }
 
   @NotThreadSafe

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/rest/user/PostSwapCrossHisorders.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/rest/user/PostSwapCrossHisorders.java
@@ -132,5 +132,12 @@ public final class PostSwapCrossHisorders extends UserRestRequest<PostSwapCrossH
   public static final class Data extends PaginatedData {
 
     public List<_OrderInfo> orders;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "orders=" + orders +
+              '}';
+    }
   }
 }

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/rest/user/PostSwapCrossOpenorders.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/rest/user/PostSwapCrossOpenorders.java
@@ -103,5 +103,12 @@ public final class PostSwapCrossOpenorders
   public static final class Data extends PaginatedData {
 
     public List<_OrderInfo> orders;
+
+    @Override
+    public String toString() {
+      return "Data{" +
+              "orders=" + orders +
+              '}';
+    }
   }
 }

--- a/kraken-api/src/main/java/io/contek/invoker/kraken/api/common/_Book.java
+++ b/kraken-api/src/main/java/io/contek/invoker/kraken/api/common/_Book.java
@@ -13,4 +13,14 @@ public final class _Book {
   // update payload
   public List<_BookLevel> a;
   public List<_BookLevel> b;
+
+  @Override
+  public String toString() {
+    return "_Book{" +
+            "as=" + as +
+            ", bs=" + bs +
+            ", a=" + a +
+            ", b=" + b +
+            '}';
+  }
 }

--- a/kraken-api/src/main/java/io/contek/invoker/kraken/api/common/_BookLevel.java
+++ b/kraken-api/src/main/java/io/contek/invoker/kraken/api/common/_BookLevel.java
@@ -19,4 +19,14 @@ public final class _BookLevel {
     }
     return level;
   }
+
+  @Override
+  public String toString() {
+    return "_BookLevel{" +
+            "price=" + price +
+            ", volume=" + volume +
+            ", timestamp=" + timestamp +
+            ", updateType='" + updateType + '\'' +
+            '}';
+  }
 }

--- a/kraken-api/src/main/java/io/contek/invoker/kraken/api/common/_Trade.java
+++ b/kraken-api/src/main/java/io/contek/invoker/kraken/api/common/_Trade.java
@@ -10,4 +10,16 @@ public final class _Trade {
   public String side;
   public String orderType;
   public String misc;
+
+  @Override
+  public String toString() {
+    return "_Trade{" +
+            "price=" + price +
+            ", volume=" + volume +
+            ", time=" + time +
+            ", side='" + side + '\'' +
+            ", orderType='" + orderType + '\'' +
+            ", misc='" + misc + '\'' +
+            '}';
+  }
 }


### PR DESCRIPTION
Accept null value for RestParams, modify gson instance in RestMediaType and type of map used in RestParams and RestParamsBuild

Why accept null value? For example in FTX, when you want post market order you dont need specialized price value. This value can to be null. The default constructor of Gson don't serialize null value.