### PR TITLE
Add GsonFactory with improved number parsing

### DIFF
--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/MarketWebSocketMessageParser.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/market/MarketWebSocketMessageParser.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.contek.invoker.binancedelivery.api.websocket.common.WebSocketCommandConfirmation;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -17,7 +18,7 @@ import static io.contek.invoker.binancedelivery.api.websocket.common.constants.W
 @Immutable
 public final class MarketWebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static MarketWebSocketMessageParser getInstance() {
     return InstanceHolder.INSTANCE;

--- a/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/UserWebSocketParser.java
+++ b/binancedelivery-api/src/main/java/io/contek/invoker/binancedelivery/api/websocket/user/UserWebSocketParser.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.contek.invoker.binancedelivery.api.websocket.common.WebSocketEventMessage;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
 
@@ -15,7 +16,7 @@ import static io.contek.invoker.binancedelivery.api.websocket.user.constants.Use
 @ThreadSafe
 public final class UserWebSocketParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static UserWebSocketParser getInstance() {
     return InstanceHolder.INSTANCE;

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/MarketWebSocketMessageParser.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/market/MarketWebSocketMessageParser.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.contek.invoker.binancefutures.api.websocket.common.WebSocketCommandConfirmation;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -17,7 +18,7 @@ import static io.contek.invoker.binancefutures.api.websocket.common.constants.We
 @Immutable
 public final class MarketWebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static MarketWebSocketMessageParser getInstance() {
     return MarketWebSocketMessageParser.InstanceHolder.INSTANCE;

--- a/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/UserWebSocketParser.java
+++ b/binancefutures-api/src/main/java/io/contek/invoker/binancefutures/api/websocket/user/UserWebSocketParser.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.contek.invoker.binancefutures.api.websocket.common.WebSocketEventMessage;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
 
@@ -15,7 +16,7 @@ import static io.contek.invoker.binancefutures.api.websocket.user.constants.User
 @ThreadSafe
 public final class UserWebSocketParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static UserWebSocketParser getInstance() {
     return UserWebSocketParser.InstanceHolder.INSTANCE;

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/MarketWebSocketMessageParser.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/market/MarketWebSocketMessageParser.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.contek.invoker.binancespot.api.websocket.common.WebSocketCommandConfirmation;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -17,7 +18,7 @@ import static io.contek.invoker.binancespot.api.websocket.common.constants.WebSo
 @Immutable
 public final class MarketWebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static MarketWebSocketMessageParser getInstance() {
     return MarketWebSocketMessageParser.InstanceHolder.INSTANCE;

--- a/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/user/UserWebSocketParser.java
+++ b/binancespot-api/src/main/java/io/contek/invoker/binancespot/api/websocket/user/UserWebSocketParser.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.contek.invoker.binancespot.api.websocket.common.WebSocketEventMessage;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
 
@@ -13,7 +14,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class UserWebSocketParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static UserWebSocketParser getInstance() {
     return UserWebSocketParser.InstanceHolder.INSTANCE;

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetExecution.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetExecution.java
@@ -3,6 +3,7 @@ package io.contek.invoker.bitmex.api.rest.user;
 import com.google.gson.Gson;
 import io.contek.invoker.bitmex.api.common._Execution;
 import io.contek.invoker.bitmex.api.rest.user.GetExecution.Response;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.actor.IActor;
 import io.contek.invoker.commons.rest.RestContext;
 import io.contek.invoker.commons.rest.RestMethod;
@@ -19,7 +20,7 @@ import static io.contek.invoker.commons.rest.RestMethod.GET;
 @NotThreadSafe
 public final class GetExecution extends UserRestRequest<Response> {
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GsonFactory.buildGson();
 
   private String symbol;
   private String startTime;

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetExecutionTradeHistory.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetExecutionTradeHistory.java
@@ -3,6 +3,7 @@ package io.contek.invoker.bitmex.api.rest.user;
 import com.google.gson.Gson;
 import io.contek.invoker.bitmex.api.common._Execution;
 import io.contek.invoker.bitmex.api.rest.user.GetExecutionTradeHistory.Response;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.actor.IActor;
 import io.contek.invoker.commons.rest.RestContext;
 import io.contek.invoker.commons.rest.RestMethod;
@@ -19,7 +20,7 @@ import static io.contek.invoker.commons.rest.RestMethod.GET;
 @NotThreadSafe
 public final class GetExecutionTradeHistory extends UserRestRequest<Response> {
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GsonFactory.buildGson();
 
   private String symbol;
   private String startTime;

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetOrder.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetOrder.java
@@ -3,6 +3,7 @@ package io.contek.invoker.bitmex.api.rest.user;
 import com.google.gson.Gson;
 import io.contek.invoker.bitmex.api.common._Order;
 import io.contek.invoker.bitmex.api.rest.user.GetOrder.Response;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.actor.IActor;
 import io.contek.invoker.commons.rest.RestContext;
 import io.contek.invoker.commons.rest.RestMethod;
@@ -19,7 +20,7 @@ import static io.contek.invoker.commons.rest.RestMethod.GET;
 @NotThreadSafe
 public final class GetOrder extends UserRestRequest<Response> {
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GsonFactory.buildGson();
 
   private String symbol;
   private Integer count;

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetPosition.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/rest/user/GetPosition.java
@@ -3,6 +3,7 @@ package io.contek.invoker.bitmex.api.rest.user;
 import com.google.gson.Gson;
 import io.contek.invoker.bitmex.api.common._Position;
 import io.contek.invoker.bitmex.api.rest.user.GetPosition.Response;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.actor.IActor;
 import io.contek.invoker.commons.rest.RestContext;
 import io.contek.invoker.commons.rest.RestMethod;
@@ -19,7 +20,7 @@ import static io.contek.invoker.commons.rest.RestMethod.GET;
 @NotThreadSafe
 public final class GetPosition extends UserRestRequest<Response> {
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GsonFactory.buildGson();
 
   private Integer count;
   private final Map<String, String> filter = new HashMap<>();

--- a/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/websocket/WebSocketMessageParser.java
+++ b/bitmex-api/src/main/java/io/contek/invoker/bitmex/api/websocket/WebSocketMessageParser.java
@@ -8,6 +8,7 @@ import io.contek.invoker.bitmex.api.websocket.market.*;
 import io.contek.invoker.bitmex.api.websocket.user.ExecutionChannel;
 import io.contek.invoker.bitmex.api.websocket.user.OrderChannel;
 import io.contek.invoker.bitmex.api.websocket.user.PositionChannel;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -21,7 +22,7 @@ import static io.contek.invoker.commons.websocket.constants.WebSocketPingPongKey
 @Immutable
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static WebSocketMessageParser getInstance() {
     return InstanceHolder.INSTANCE;

--- a/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/websocket/WebSocketMessageParser.java
+++ b/bitstamp-api/src/main/java/io/contek/invoker/bitstamp/api/websocket/WebSocketMessageParser.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import io.contek.invoker.bitstamp.api.websocket.common.WebSocketRequestConfirmationMessage;
 import io.contek.invoker.bitstamp.api.websocket.market.DiffOrderBookChannel;
 import io.contek.invoker.bitstamp.api.websocket.market.LiveTradesChannel;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -19,7 +20,7 @@ import static io.contek.invoker.bitstamp.api.websocket.common.constants.WebSocke
 @Immutable
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static WebSocketMessageParser getInstance() {
     return InstanceHolder.INSTANCE;

--- a/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/WebSocketMessageParser.java
+++ b/bybit-api/src/main/java/io/contek/invoker/bybit/api/websocket/WebSocketMessageParser.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import io.contek.invoker.bybit.api.websocket.common.WebSocketOperationResponse;
 import io.contek.invoker.bybit.api.websocket.common.WebSocketTopicMessage;
 import io.contek.invoker.bybit.api.websocket.market.OrderBookChannel;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -20,7 +21,7 @@ import static io.contek.invoker.bybit.api.websocket.common.constants.WebSocketDa
 @ThreadSafe
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   private final Map<String, Class<? extends WebSocketTopicMessage>> channelMessageTypes =
       new HashMap<>();

--- a/bybitlinear-api/src/main/java/io/contek/invoker/bybitlinear/api/websocket/WebSocketMessageParser.java
+++ b/bybitlinear-api/src/main/java/io/contek/invoker/bybitlinear/api/websocket/WebSocketMessageParser.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import io.contek.invoker.bybitlinear.api.websocket.common.WebSocketOperationResponse;
 import io.contek.invoker.bybitlinear.api.websocket.common.WebSocketTopicMessage;
 import io.contek.invoker.bybitlinear.api.websocket.market.OrderBookChannel;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -20,7 +21,7 @@ import static io.contek.invoker.bybitlinear.api.websocket.common.constants.WebSo
 @ThreadSafe
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   private final Map<String, Class<? extends WebSocketTopicMessage>> channelMessageTypes =
       new HashMap<>();

--- a/coinbasepro-api/src/main/java/io/contek/invoker/coinbasepro/api/websocket/WebSocketMessageParser.java
+++ b/coinbasepro-api/src/main/java/io/contek/invoker/coinbasepro/api/websocket/WebSocketMessageParser.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import io.contek.invoker.coinbasepro.api.websocket.common.WebSocketSubscriptionMessage;
 import io.contek.invoker.coinbasepro.api.websocket.market.Level2Channel;
 import io.contek.invoker.coinbasepro.api.websocket.market.MatchesChannel;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -17,7 +18,7 @@ import static io.contek.invoker.coinbasepro.api.websocket.common.constants.WebSo
 @Immutable
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static WebSocketMessageParser getInstance() {
     return InstanceHolder.INSTANCE;

--- a/commons/src/main/java/io/contek/invoker/commons/GsonFactory.java
+++ b/commons/src/main/java/io/contek/invoker/commons/GsonFactory.java
@@ -1,0 +1,131 @@
+package io.contek.invoker.commons;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class GsonFactory {
+  private GsonFactory() {
+  }
+
+  public static Gson buildGson() {
+    return new GsonBuilder()
+        .serializeNulls()
+        .registerTypeAdapter(Integer.class, new IntegerTypeAdapter())
+        .registerTypeAdapter(int.class, new IntegerTypeAdapter())
+        .registerTypeAdapter(Long.class, new LongTypeAdapter())
+        .registerTypeAdapter(long.class, new LongTypeAdapter())
+        .registerTypeAdapter(Double.class, new DoubleTypeAdapter())
+        .registerTypeAdapter(double.class, new DoubleTypeAdapter())
+        .create();
+  }
+
+  private static class IntegerTypeAdapter extends TypeAdapter<Integer> {
+    @Override
+    public void write(JsonWriter out, Integer value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+        return;
+      }
+      out.value(value);
+    }
+
+    @Override
+    public Integer read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+
+      try {
+        String value = in.nextString();
+        if ("".equals(value)) {
+          return null;
+        }
+        if (value.contains(".")) {
+          while (value.endsWith("0")) {
+            value = value.substring(0, value.length() - 1);
+          }
+          if (value.endsWith(".")) {
+            value = value.substring(0, value.length() - 1);
+          }
+        }
+        return Integer.valueOf(value);
+      } catch (NumberFormatException e) {
+        throw new JsonSyntaxException(e);
+      }
+    }
+  }
+
+  private static class LongTypeAdapter extends TypeAdapter<Long> {
+    @Override
+    public void write(JsonWriter out, Long value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+        return;
+      }
+      out.value(value);
+    }
+
+    @Override
+    public Long read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+
+      try {
+        String value = in.nextString();
+        if ("".equals(value)) {
+          return null;
+        }
+        if (value.contains(".")) {
+          while (value.endsWith("0")) {
+            value = value.substring(0, value.length() - 1);
+          }
+          if (value.endsWith(".")) {
+            value = value.substring(0, value.length() - 1);
+          }
+        }
+        return Long.valueOf(value);
+      } catch (NumberFormatException e) {
+        throw new JsonSyntaxException(e);
+      }
+    }
+  }
+
+  private static class DoubleTypeAdapter extends TypeAdapter<Double> {
+    @Override
+    public void write(JsonWriter out, Double value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+        return;
+      }
+      out.value(value);
+    }
+
+    @Override
+    public Double read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+
+      try {
+        String value = in.nextString();
+        if ("".equals(value)) {
+          return null;
+        }
+        return Double.valueOf(value);
+      } catch (NumberFormatException e) {
+        throw new JsonSyntaxException(e);
+      }
+    }
+  }
+}

--- a/commons/src/main/java/io/contek/invoker/commons/rest/RestMediaType.java
+++ b/commons/src/main/java/io/contek/invoker/commons/rest/RestMediaType.java
@@ -1,6 +1,7 @@
 package io.contek.invoker.commons.rest;
 
 import com.google.gson.Gson;
+import io.contek.invoker.commons.GsonFactory;
 import okhttp3.MediaType;
 
 import javax.annotation.concurrent.Immutable;
@@ -17,7 +18,7 @@ public enum RestMediaType {
       requireNonNull(MediaType.parse("application/x-www-form-urlencoded")),
       RestMediaType::toFormString);
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GsonFactory.buildGson();
 
   private final MediaType value;
   private final Function<RestParams, String> composer;

--- a/commons/src/main/java/io/contek/invoker/commons/rest/RestResponse.java
+++ b/commons/src/main/java/io/contek/invoker/commons/rest/RestResponse.java
@@ -2,6 +2,7 @@ package io.contek.invoker.commons.rest;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import io.contek.invoker.commons.GsonFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -9,7 +10,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class RestResponse {
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GsonFactory.buildGson();
 
   private final int code;
   private final String stringValue;

--- a/commons/src/main/java/io/contek/invoker/commons/websocket/WebSocketSession.java
+++ b/commons/src/main/java/io/contek/invoker/commons/websocket/WebSocketSession.java
@@ -1,6 +1,7 @@
 package io.contek.invoker.commons.websocket;
 
 import com.google.gson.Gson;
+import io.contek.invoker.commons.GsonFactory;
 import okhttp3.WebSocket;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -8,7 +9,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class WebSocketSession {
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GsonFactory.buildGson();
 
   private final WebSocket ws;
 

--- a/deribit-api/src/main/java/io/contek/invoker/deribit/api/websocket/WebSocketMessageParser.java
+++ b/deribit-api/src/main/java/io/contek/invoker/deribit/api/websocket/WebSocketMessageParser.java
@@ -3,6 +3,7 @@ package io.contek.invoker.deribit.api.websocket;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -24,7 +25,7 @@ import static java.lang.String.format;
 @ThreadSafe
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   private final Map<Integer, Class<? extends WebSocketResponse<?>>> pendingRequests =
       new HashMap<>();

--- a/ftx-api/src/main/java/io/contek/invoker/ftx/api/websocket/WebSocketMessageParser.java
+++ b/ftx-api/src/main/java/io/contek/invoker/ftx/api/websocket/WebSocketMessageParser.java
@@ -3,6 +3,7 @@ package io.contek.invoker.ftx.api.websocket;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -23,7 +24,7 @@ import static io.contek.invoker.ftx.api.websocket.common.constants.WebSocketInbo
 @Immutable
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static WebSocketMessageParser getInstance() {
     return InstanceHolder.INSTANCE;

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/websocket/common/marketdata/MarketDataWebSocketMessageParser.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/websocket/common/marketdata/MarketDataWebSocketMessageParser.java
@@ -4,6 +4,7 @@ import com.google.common.io.CharStreams;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketBinaryMessageParser;
@@ -20,7 +21,7 @@ import java.util.zip.GZIPInputStream;
 @ThreadSafe
 final class MarketDataWebSocketMessageParser extends WebSocketBinaryMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   private final Map<String, Class<? extends MarketDataWebSocketChannelMessage>>
       channelMessageTypes = new HashMap<>();

--- a/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/websocket/common/notification/NotificationWebSocketMessageParser.java
+++ b/hbdminverse-api/src/main/java/io/contek/invoker/hbdminverse/api/websocket/common/notification/NotificationWebSocketMessageParser.java
@@ -4,6 +4,7 @@ import com.google.common.io.CharStreams;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketBinaryMessageParser;
@@ -22,7 +23,7 @@ import static io.contek.invoker.hbdminverse.api.websocket.user.constants.OpKeys.
 @Immutable
 final class NotificationWebSocketMessageParser extends WebSocketBinaryMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   private final Map<String, Class<? extends NotificationWebSocketChannelMessage>>
       channelMessageTypes = new HashMap<>();

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/websocket/common/marketdata/MarketDataWebSocketMessageParser.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/websocket/common/marketdata/MarketDataWebSocketMessageParser.java
@@ -4,6 +4,7 @@ import com.google.common.io.CharStreams;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketBinaryMessageParser;
@@ -20,7 +21,7 @@ import java.util.zip.GZIPInputStream;
 @ThreadSafe
 final class MarketDataWebSocketMessageParser extends WebSocketBinaryMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   private final Map<String, Class<? extends MarketDataWebSocketChannelMessage>>
       channelMessageTypes = new HashMap<>();

--- a/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/websocket/common/notification/NotificationWebSocketMessageParser.java
+++ b/hbdmlinear-api/src/main/java/io/contek/invoker/hbdmlinear/api/websocket/common/notification/NotificationWebSocketMessageParser.java
@@ -4,6 +4,7 @@ import com.google.common.io.CharStreams;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketBinaryMessageParser;
@@ -22,7 +23,7 @@ import static io.contek.invoker.hbdmlinear.api.websocket.user.constants.OpKeys.*
 @Immutable
 final class NotificationWebSocketMessageParser extends WebSocketBinaryMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   private final Map<String, Class<? extends NotificationWebSocketChannelMessage>>
       channelMessageTypes = new HashMap<>();

--- a/kraken-api/src/main/java/io/contek/invoker/kraken/api/websocket/WebSocketMessageParser.java
+++ b/kraken-api/src/main/java/io/contek/invoker/kraken/api/websocket/WebSocketMessageParser.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.AnyWebSocketMessage;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
@@ -29,7 +30,7 @@ final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
   private static final String FIELD_EVENT = "event";
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static WebSocketMessageParser getInstance() {
     return InstanceHolder.INSTANCE;

--- a/okx-api/src/main/java/io/contek/invoker/okx/api/websocket/WebSocketMessageParser.java
+++ b/okx-api/src/main/java/io/contek/invoker/okx/api/websocket/WebSocketMessageParser.java
@@ -3,6 +3,7 @@ package io.contek.invoker.okx.api.websocket;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.contek.invoker.commons.GsonFactory;
 import io.contek.invoker.commons.websocket.IWebSocketComponent;
 import io.contek.invoker.commons.websocket.WebSocketTextMessageParser;
 import io.contek.invoker.okx.api.websocket.common.*;
@@ -22,7 +23,7 @@ import static io.contek.invoker.okx.api.websocket.common.constants.WebSocketOutb
 @Immutable
 final class WebSocketMessageParser extends WebSocketTextMessageParser {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = GsonFactory.buildGson();
 
   static WebSocketMessageParser getInstance() {
     return InstanceHolder.INSTANCE;


### PR DESCRIPTION
This GsonFactory contains improved number parsing.

Example:
An API returns a contract size with a trailing ".0". Even though one can be sure that it is suppost to be an integer, Gson by default would throw a NumberFormatException.
The added TypeAdapter's in this pull request cut away trailing decimal places if they are 0 and by that make it possible to parse a number like 1.0 to an integer or long.